### PR TITLE
Modified regex to self matcher

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -19,6 +19,8 @@ type PullRequest struct {
 	Number   int
 }
 
+var ciRegexp = regexp.MustCompile(`[1-9]\d*$`)
+
 func circleci() (ci CI, err error) {
 	ci.PR.Number = 0
 	ci.PR.Revision = os.Getenv("CIRCLE_SHA1")
@@ -33,8 +35,7 @@ func circleci() (ci CI, err error) {
 	if pr == "" {
 		return ci, nil
 	}
-	re := regexp.MustCompile(`[1-9]\d*$`)
-	ci.PR.Number, err = strconv.Atoi(re.FindString(pr))
+	ci.PR.Number, err = strconv.Atoi(ciRegexp.FindString(pr))
 	if err != nil {
 		return ci, fmt.Errorf("%v: cannot get env", pr)
 	}


### PR DESCRIPTION
## WHAT

Improved to use regexp.

## WHY

I want to improve performance and correct how to use regexp.

In `GetDuplicates`

```
goos: darwin
goarch: amd64
pkg: github.com/mercari/tfnotify/notifier/github
BenchmarkGetDuplicates-8          100000             17613 ns/op           17406 B/op        167 allocs/op
BenchmarkOldGetDuplicates-8        30000             50489 ns/op          111038 B/op        267 allocs/op
PASS
ok      github.com/mercari/tfnotify/notifier/github     4.022s
```