### PR TITLE
Display all error messages, not just one line

### DIFF
--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -102,12 +102,19 @@ func (p *PlanParser) Parse(body string) ParseResult {
 			Error:    fmt.Errorf("cannot parse plan result"),
 		}
 	}
-	var result string
 	lines := strings.Split(body, "\n")
-	for _, line := range lines {
+	var i int
+	var result, line string
+	for i, line = range lines {
 		if p.Pass.MatchString(line) || p.Fail.MatchString(line) {
-			result = line
+			break
 		}
+	}
+	switch {
+	case p.Pass.MatchString(line):
+		result = lines[i]
+	case p.Fail.MatchString(line):
+		result = strings.Join(trimLastNewline(lines[i:]), "\n")
 	}
 	return ParseResult{
 		Result:   result,
@@ -131,16 +138,20 @@ func (p *ApplyParser) Parse(body string) ParseResult {
 			Error:    fmt.Errorf("cannot parse apply result"),
 		}
 	}
-	var result string
 	lines := strings.Split(body, "\n")
 	var i int
-	for idx, line := range lines {
+	var result, line string
+	for i, line = range lines {
 		if p.Pass.MatchString(line) || p.Fail.MatchString(line) {
-			i = idx
 			break
 		}
 	}
-	result = strings.Join(trimLastNewline(lines[i:]), "\n")
+	switch {
+	case p.Pass.MatchString(line):
+		result = lines[i]
+	case p.Fail.MatchString(line):
+		result = strings.Join(trimLastNewline(lines[i:]), "\n")
+	}
 	return ParseResult{
 		Result:   result,
 		ExitCode: exitCode,

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -76,7 +76,13 @@ const planFailureResult = `
 xxxxxxxxx
 xxxxxxxxx
 xxxxxxxxx
-Error: Required variable not set: my_service_dev_google_sql_user_proxyuser_password
+
+Error: Error refreshing state: 4 error(s) occurred:
+
+* google_sql_database.main: 1 error(s) occurred:
+
+* google_sql_database.main: google_sql_database.main: Error reading SQL Database "main" in instance "main-master-instance": googleapi: Error 409: The instance or operation is not in an appropriate state to handle the request., invalidState
+* google_sql_user.proxyuser_main: 1 error(s) occurred:
 `
 
 const planNoChanges = `
@@ -263,7 +269,12 @@ func TestPlanParserParse(t *testing.T) {
 			name: "plan ng pattern",
 			body: planFailureResult,
 			result: ParseResult{
-				Result:   "Error: Required variable not set: my_service_dev_google_sql_user_proxyuser_password",
+				Result: `Error: Error refreshing state: 4 error(s) occurred:
+
+* google_sql_database.main: 1 error(s) occurred:
+
+* google_sql_database.main: google_sql_database.main: Error reading SQL Database "main" in instance "main-master-instance": googleapi: Error 409: The instance or operation is not in an appropriate state to handle the request., invalidState
+* google_sql_user.proxyuser_main: 1 error(s) occurred:`,
 				ExitCode: 1,
 				Error:    nil,
 			},


### PR DESCRIPTION
## WHAT

When some error occurs, display all lines related to errors, not just only the title line of that error

## WHY

We don't know the details as it is, so we have to press "details" tag. All logs should be hidden by "detail" tag. However, if it is just error lines, it should be displayed all.

NOW:

![2018-05-09 18 42 34](https://user-images.githubusercontent.com/4442708/39814790-aa1148fc-53d0-11e8-85a3-e8a44aeaa620.png)
