### PR TITLE
Make CI link available in template

### DIFF
--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -26,6 +26,7 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 		Message: cfg.PR.Message,
 		Result:  result.Result,
 		Body:    body,
+		Link:    cfg.CI,
 	})
 	body, err = template.Execute()
 	if err != nil {

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -88,6 +88,7 @@ type CommonTemplate struct {
 	Message string
 	Result  string
 	Body    string
+	Link    string
 }
 
 // DefaultTemplate is a default template for terraform commands
@@ -170,6 +171,7 @@ func (t *DefaultTemplate) Execute() (resp string, err error) {
 		"Message": t.Message,
 		"Result":  "",
 		"Body":    t.Result,
+		"Link":    t.Link,
 	}); err != nil {
 		return resp, err
 	}
@@ -189,6 +191,7 @@ func (t *FmtTemplate) Execute() (resp string, err error) {
 		"Message": t.Message,
 		"Result":  "",
 		"Body":    t.Result,
+		"Link":    t.Link,
 	}); err != nil {
 		return resp, err
 	}
@@ -208,6 +211,7 @@ func (t *PlanTemplate) Execute() (resp string, err error) {
 		"Message": t.Message,
 		"Result":  t.Result,
 		"Body":    t.Body,
+		"Link":    t.Link,
 	}); err != nil {
 		return resp, err
 	}
@@ -227,6 +231,7 @@ func (t *ApplyTemplate) Execute() (resp string, err error) {
 		"Message": t.Message,
 		"Result":  t.Result,
 		"Body":    t.Body,
+		"Link":    t.Link,
 	}); err != nil {
 		return resp, err
 	}


### PR DESCRIPTION
## WHAT

By changing `tfnotify.yaml` as follows, make CI link available in template (e.g. github comment):

```diff
 terraform:
   plan:
     template: |
-      {{ .Title }}
+      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
       {{ .Message }}
       {{if .Result}}
       <pre><code> {{ .Result }}
```

![2018-05-29 20 24 38](https://user-images.githubusercontent.com/4442708/40656793-7802f71a-6380-11e8-8069-843035336135.png)

In case of Circle CI, `{{ .Link }}` will be linked to the build page link such as https://circleci.com/gh/repo/org/1101

## WHY

Make it easy to jump the CI page
