### PR TITLE
Fix #10 support conditional notification based on matching parse exitcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ notifier:
     repository:
       owner: "mercari"
       name: "tfnotify"
+    filters:
+      parse_exit_code: 1
 terraform:
   fmt:
     template: |
@@ -133,6 +135,8 @@ notifier:
     token: $SLACK_TOKEN
     channel: $SLACK_CHANNEL_ID
     bot: $SLACK_BOT_NAME
+    filters:
+      parse_exit_code: 1
 terraform:
   plan:
     template: |

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Notifier struct {
 type GithubNotifier struct {
 	Token      string     `yaml:"token"`
 	Repository Repository `yaml:"repository"`
+	Filters    *Filters   `yaml:"filters"`
 }
 
 // Repository represents a GitHub repository
@@ -39,9 +40,15 @@ type Repository struct {
 
 // SlackNotifier is a notifier for Slack
 type SlackNotifier struct {
-	Token   string `yaml:"token"`
-	Channel string `yaml:"channel"`
-	Bot     string `yaml:"bot"`
+	Token   string   `yaml:"token"`
+	Channel string   `yaml:"channel"`
+	Bot     string   `yaml:"bot"`
+	Filters *Filters `yaml:"filters"`
+}
+
+// Filters is conditions for notification
+type Filters struct {
+	ParseExitCode int `yaml:"parse_exit_code"`
 }
 
 // Terraform represents terraform configurations
@@ -156,4 +163,9 @@ func (cfg *Config) Find(file string) (string, error) {
 		}
 	}
 	return "", errors.New("config for tfnotify is not found at all")
+}
+
+// Match returns terraform result matches conditions or not
+func (filters *Filters) Match(exitCode int) bool {
+	return filters == nil || exitCode == filters.ParseExitCode
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -317,3 +317,37 @@ func TestFind(t *testing.T) {
 		}
 	}
 }
+
+func TestFiltersMatch(t *testing.T) {
+	testCases := []struct {
+		filters  *Filters
+		exitCode int
+		expect   bool
+	}{
+		{
+			nil,
+			1,
+			true,
+		},
+		{
+			&Filters{
+				ParseExitCode: 1,
+			},
+			1,
+			true,
+		},
+		{
+			&Filters{
+				ParseExitCode: 1,
+			},
+			0,
+			false,
+		},
+	}
+	for _, testCase := range testCases {
+		actual := testCase.filters.Match(testCase.exitCode)
+		if actual != testCase.expect {
+			t.Errorf("got %t but want %t", actual, testCase.expect)
+		}
+	}
+}

--- a/error.go
+++ b/error.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+
+	"github.com/mercari/tfnotify/notifier"
 )
 
 // Exit codes are int values for the exit code that shell interpreter can interpret
@@ -54,6 +56,11 @@ func (ee *ExitError) ExitCode() int {
 // This function is heavily inspired by urfave/cli.HandleExitCoder
 func HandleExit(err error) int {
 	if err == nil {
+		return ExitCodeOK
+	}
+
+	// Ignore nop
+	if err == notifier.ErrNop {
 		return ExitCodeOK
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"testing"
+
+	"github.com/mercari/tfnotify/notifier"
 )
 
 func TestHandleError(t *testing.T) {
@@ -32,6 +34,10 @@ func TestHandleError(t *testing.T) {
 		},
 		{
 			err:      nil,
+			exitCode: 0,
+		},
+		{
+			err:      notifier.ErrNop,
 			exitCode: 0,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func (t *tfnotify) Run() error {
 			CI:       ci.URL,
 			Parser:   t.parser,
 			Template: t.template,
+			Filters:  t.config.Notifier.Github.Filters,
 		})
 		if err != nil {
 			return err
@@ -87,6 +88,7 @@ func (t *tfnotify) Run() error {
 			CI:       ci.URL,
 			Parser:   t.parser,
 			Template: t.template,
+			Filters:  t.config.Notifier.Slack.Filters,
 		})
 		if err != nil {
 			return err

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
+	"github.com/mercari/tfnotify/config"
 	"github.com/mercari/tfnotify/terraform"
 	"golang.org/x/oauth2"
 )
@@ -38,6 +39,7 @@ type Config struct {
 	CI       string
 	Parser   terraform.Parser
 	Template terraform.Template
+	Filters  *config.Filters
 }
 
 // PullRequest represents GitHub Pull Request metadata

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"github.com/mercari/tfnotify/notifier"
 	"github.com/mercari/tfnotify/terraform"
 )
 
@@ -13,6 +14,7 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 	cfg := g.client.Config
 	parser := g.client.Config.Parser
 	template := g.client.Config.Template
+	filters := g.client.Config.Filters
 
 	result := parser.Parse(body)
 	if result.Error != nil {
@@ -20,6 +22,10 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 	}
 	if result.Result == "" {
 		return result.ExitCode, result.Error
+	}
+
+	if !filters.Match(result.ExitCode) {
+		return result.ExitCode, notifier.ErrNop
 	}
 
 	template.SetValue(terraform.CommonTemplate{

--- a/notifier/github/notify_test.go
+++ b/notifier/github/notify_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"testing"
 
+	"github.com/mercari/tfnotify/config"
 	"github.com/mercari/tfnotify/terraform"
 )
 
@@ -26,6 +27,7 @@ func TestNotifyNotify(t *testing.T) {
 				},
 				Parser:   terraform.NewPlanParser(),
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters:  nil,
 			},
 			body:     "body",
 			ok:       false,
@@ -44,6 +46,7 @@ func TestNotifyNotify(t *testing.T) {
 				},
 				Parser:   terraform.NewPlanParser(),
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters:  nil,
 			},
 			body:     "Plan: 1 to add",
 			ok:       false,
@@ -62,6 +65,7 @@ func TestNotifyNotify(t *testing.T) {
 				},
 				Parser:   terraform.NewPlanParser(),
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters:  nil,
 			},
 			body:     "Error: hoge",
 			ok:       true,
@@ -80,6 +84,7 @@ func TestNotifyNotify(t *testing.T) {
 				},
 				Parser:   terraform.NewPlanParser(),
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters:  nil,
 			},
 			body:     "Plan: 1 to add",
 			ok:       true,
@@ -98,9 +103,31 @@ func TestNotifyNotify(t *testing.T) {
 				},
 				Parser:   terraform.NewPlanParser(),
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters:  nil,
 			},
 			body:     "Plan: 1 to add",
 			ok:       true,
+			exitCode: 0,
+		},
+		{
+			// valid, filter mismatch
+			config: Config{
+				Token: "token",
+				Owner: "owner",
+				Repo:  "repo",
+				PR: PullRequest{
+					Revision: "",
+					Number:   1,
+					Message:  "message",
+				},
+				Parser:   terraform.NewPlanParser(),
+				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters: &config.Filters{
+					ParseExitCode: 1,
+				},
+			},
+			body:     "Plan: 1 to add", // ParseExitCode is 0
+			ok:       false,            // nop
 			exitCode: 0,
 		},
 		{
@@ -116,6 +143,7 @@ func TestNotifyNotify(t *testing.T) {
 				},
 				Parser:   terraform.NewApplyParser(),
 				Template: terraform.NewApplyTemplate(terraform.DefaultApplyTemplate),
+				Filters:  nil,
 			},
 			body:     "Apply complete!",
 			ok:       true,

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,5 +1,13 @@
 package notifier
 
+import (
+	"errors"
+)
+
+var (
+	ErrNop = errors.New("notification wasn't operated")
+)
+
 // Notifier is a notification interface
 type Notifier interface {
 	Notify(body string) (exit int, err error)

--- a/notifier/slack/client.go
+++ b/notifier/slack/client.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mercari/tfnotify/terraform"
 	"github.com/lestrrat-go/slack"
+	"github.com/mercari/tfnotify/config"
+	"github.com/mercari/tfnotify/terraform"
 )
 
 // EnvToken is Slack API Token
@@ -34,6 +35,7 @@ type Config struct {
 	CI       string
 	Parser   terraform.Parser
 	Template terraform.Template
+	Filters  *config.Filters
 }
 
 type service struct {

--- a/notifier/slack/notify_test.go
+++ b/notifier/slack/notify_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mercari/tfnotify/terraform"
 	"github.com/lestrrat-go/slack/objects"
+	"github.com/mercari/tfnotify/config"
+	"github.com/mercari/tfnotify/terraform"
 )
 
 func TestNotify(t *testing.T) {
@@ -23,6 +24,7 @@ func TestNotify(t *testing.T) {
 				Message:  "",
 				Parser:   terraform.NewPlanParser(),
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters:  nil,
 			},
 			body:     "Plan: 1 to add",
 			exitCode: 0,
@@ -36,10 +38,27 @@ func TestNotify(t *testing.T) {
 				Message:  "",
 				Parser:   terraform.NewPlanParser(),
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters:  nil,
 			},
 			body:     "Plan: 1 to add",
 			exitCode: 1,
 			ok:       false,
+		},
+		{
+			config: Config{
+				Token:    "token",
+				Channel:  "channel",
+				Botname:  "botname",
+				Message:  "",
+				Parser:   terraform.NewPlanParser(),
+				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				Filters: &config.Filters{
+					ParseExitCode: 1,
+				},
+			},
+			body:     "Plan: 1 to add", // ParseExitCode is 0
+			exitCode: 0,
+			ok:       false, // nop
 		},
 	}
 	fake := fakeAPI{


### PR DESCRIPTION
## WHAT
Support conditional notification on both of slack and github notifiers. In this pullreq, support only matching parser exitcode.

## WHY
To do more flexible notifying. See detail on https://github.com/mercari/tfnotify/issues/10