### PR TITLE
Expand the condition as to whether it is a duplicate comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ dep: devel-deps
 
 .PHONY: reviewdog
 reviewdog: devel-deps
-	reviewdog -reporter="github-pr-check"
+	reviewdog -reporter="github-pr-review"
 
 .PHONY: coverage
 coverage: devel-deps

--- a/notifier/github/comment.go
+++ b/notifier/github/comment.go
@@ -73,7 +73,7 @@ func (g *CommentService) DeleteDuplicates(title string) {
 
 func (g *CommentService) getDuplicates(title string) []*github.IssueComment {
 	var dup []*github.IssueComment
-	re := regexp.MustCompile(`(?m)^(\n+)?` + title + `\n+` + g.client.Config.PR.Message + `\n+`)
+	re := regexp.MustCompile(`(?m)^(\n+)?` + title + `( +.*)?\n+` + g.client.Config.PR.Message + `\n+`)
 
 	comments, _ := g.client.Comment.List(g.client.Config.PR.Number)
 	for _, comment := range comments {

--- a/notifier/github/comment_test.go
+++ b/notifier/github/comment_test.go
@@ -175,6 +175,10 @@ func TestCommentGetDuplicates(t *testing.T) {
 				ID:   github.Int64(371765744),
 				Body: github.String("## Plan result\nbaz message\n"),
 			},
+			&github.IssueComment{
+				ID:   github.Int64(371765745),
+				Body: github.String("## Plan result <build URL>\nbaz message\n"),
+			},
 		}
 		return comments, nil, nil
 	}
@@ -198,6 +202,20 @@ func TestCommentGetDuplicates(t *testing.T) {
 			title:    "## Plan result",
 			message:  "hoge message",
 			comments: nil,
+		},
+		{
+			title:   "## Plan result",
+			message: "baz message",
+			comments: []*github.IssueComment{
+				&github.IssueComment{
+					ID:   github.Int64(371765744),
+					Body: github.String("## Plan result\nbaz message\n"),
+				},
+				&github.IssueComment{
+					ID:   github.Int64(371765745),
+					Body: github.String("## Plan result <build URL>\nbaz message\n"),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
## WHAT

In GitHub's comment, duplicate comments should be limited to those matched only for titles.

## WHY

Because `.Link` is changed every time if the template is set as follows, it's not recognized as duplicate comment.

```yaml
terraform:
  plan:
    template: |
      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
```
