### PR TITLE
Update Makefile for reviewdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ dep: devel-deps
 
 .PHONY: reviewdog
 reviewdog: devel-deps
-	reviewdog -ci="circle-ci"
+	reviewdog -reporter="github-pr-check"
 
 .PHONY: coverage
 coverage: devel-deps


### PR DESCRIPTION
## WHAT

- Fix reviewdog usage
  - Change `-ci` flag to `-reporter` flag

## WHY

Follow the latest usage
