### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For `plan` command, you also need to specify `plan` as the argument of tfnotify.
 
 When running tfnotify, you can specify the configuration path via `--config` option (if it's omitted, it defaults to `{.,}tfnotify.y{,a}ml`).
 
-The example settings of GitHub and Slack are as follows. Incidentally, there is no need to replace TOKEN string such as `$GITHUB_TOKEN` with the actual token. Instead, it must be defined as environment variables in CI settings.
+The example settings of GitHub, GitHub Enterprise and Slack are as follows. Incidentally, there is no need to replace TOKEN string such as `$GITHUB_TOKEN` with the actual token. Instead, it must be defined as environment variables in CI settings.
 
 [template](https://golang.org/pkg/text/template/) of Go can be used for `template`. The templates can be used in `tfnotify.yaml` are as follows:
 
@@ -83,6 +83,55 @@ ci: circleci
 notifier:
   github:
     token: $GITHUB_TOKEN
+    repository:
+      owner: "mercari"
+      name: "tfnotify"
+terraform:
+  fmt:
+    template: |
+      {{ .Title }}
+
+      {{ .Message }}
+
+      {{ .Result }}
+
+      {{ .Body }}
+  plan:
+    template: |
+      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      {{ .Message }}
+      {{if .Result}}
+      <pre><code> {{ .Result }}
+      </pre></code>
+      {{end}}
+      <details><summary>Details (Click me)</summary>
+      <pre><code> {{ .Body }}
+      </pre></code></details>
+  apply:
+    template: |
+      {{ .Title }}
+      {{ .Message }}
+      {{if .Result}}
+      <pre><code> {{ .Result }}
+      </pre></code>
+      {{end}}
+      <details><summary>Details (Click me)</summary>
+      <pre><code> {{ .Body }}
+      </pre></code></details>
+```
+
+</details>
+
+<details>
+<summary>For GitHub Enterprise</summary>
+
+```yaml
+---
+ci: circleci
+notifier:
+  github:
+    token: $GITHUB_TOKEN
+    base_url: $GITHUB_BASE_URL
     repository:
       owner: "mercari"
       name: "tfnotify"

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type Notifier struct {
 // GithubNotifier is a notifier for GitHub
 type GithubNotifier struct {
 	Token      string     `yaml:"token"`
+	BaseURL    string     `yaml:"base_url"`
 	Repository Repository `yaml:"repository"`
 }
 

--- a/main.go
+++ b/main.go
@@ -62,9 +62,10 @@ func (t *tfnotify) Run() error {
 	switch selectedNotifier {
 	case "github":
 		client, err := github.NewClient(github.Config{
-			Token: t.config.Notifier.Github.Token,
-			Owner: t.config.Notifier.Github.Repository.Owner,
-			Repo:  t.config.Notifier.Github.Repository.Name,
+			Token:   t.config.Notifier.Github.Token,
+			BaseURL: t.config.Notifier.Github.BaseURL,
+			Owner:   t.config.Notifier.Github.Repository.Owner,
+			Repo:    t.config.Notifier.Github.Repository.Name,
 			PR: github.PullRequest{
 				Revision: ci.PR.Revision,
 				Number:   ci.PR.Number,


### PR DESCRIPTION
Thank you for the great CLI tool! It would be awesome if you could take a look at this PR. 🙇

## WHAT

This PR adds support for GitHub Enterprise with `base_url` field and `GITHUB_BASE_URL` environment variable.

## WHY

It seems that tfnotify doesn't support GitHub enterprise yet.