### PR TITLE
Enable to customize title by --title option

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func (t *tfnotify) Run() error {
 			PR: github.PullRequest{
 				Revision: ci.PR.Revision,
 				Number:   ci.PR.Number,
+				Title:    t.context.String("title"),
 				Message:  t.context.String("message"),
 			},
 			CI:       ci.URL,
@@ -84,6 +85,7 @@ func (t *tfnotify) Run() error {
 			Token:    t.config.Notifier.Slack.Token,
 			Channel:  t.config.Notifier.Slack.Channel,
 			Botname:  t.config.Notifier.Slack.Bot,
+			Title:    t.context.String("title"),
 			Message:  t.context.String("message"),
 			CI:       ci.URL,
 			Parser:   t.parser,
@@ -123,6 +125,10 @@ func main() {
 			Action: cmdFmt,
 			Flags: []cli.Flag{
 				cli.StringFlag{
+					Name:  "title, t",
+					Usage: "Specify the title to use for notification",
+				},
+				cli.StringFlag{
 					Name:  "message, m",
 					Usage: "Specify the message to use for notification",
 				},
@@ -134,6 +140,10 @@ func main() {
 			Action: cmdPlan,
 			Flags: []cli.Flag{
 				cli.StringFlag{
+					Name:  "title, t",
+					Usage: "Specify the title to use for notification",
+				},
+				cli.StringFlag{
 					Name:  "message, m",
 					Usage: "Specify the message to use for notification",
 				},
@@ -144,6 +154,10 @@ func main() {
 			Usage:  "Parse stdin as a apply result",
 			Action: cmdApply,
 			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "title, t",
+					Usage: "Specify the title to use for notification",
+				},
 				cli.StringFlag{
 					Name:  "message, m",
 					Usage: "Specify the message to use for notification",

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -47,6 +47,7 @@ type Config struct {
 // PullRequest represents GitHub Pull Request metadata
 type PullRequest struct {
 	Revision string
+	Title    string
 	Message  string
 	Number   int
 }

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -23,6 +23,7 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 	}
 
 	template.SetValue(terraform.CommonTemplate{
+		Title:   cfg.PR.Title,
 		Message: cfg.PR.Message,
 		Result:  result.Result,
 		Body:    body,

--- a/notifier/slack/client.go
+++ b/notifier/slack/client.go
@@ -30,6 +30,7 @@ type Config struct {
 	Token    string
 	Channel  string
 	Botname  string
+	Title    string
 	Message  string
 	CI       string
 	Parser   terraform.Parser

--- a/notifier/slack/notify.go
+++ b/notifier/slack/notify.go
@@ -39,6 +39,7 @@ func (s *NotifyService) Notify(body string) (exit int, err error) {
 	}
 
 	template.SetValue(terraform.CommonTemplate{
+		Title:   cfg.Title,
 		Message: cfg.Message,
 		Result:  result.Result,
 		Body:    body,


### PR DESCRIPTION
## WHAT

This PR enables to customize the title by `--title` option.

## WHY

I'd like to customize the title used by notification.

We can specify the title in the config file like this:

```yaml
terraform:
  plan:
    template: |
      ## My Custom Title !!! <sup>[CI link]( {{ .Link }} )</sup>
      {{ .Message }}
      {{if .Result}}
      <pre><code> {{ .Result }}
      </pre></code>
      {{end}}
      <details><summary>Details (Click me)</summary>
      <pre><code> {{ .Body }}
      </pre></code></details>
```

But `getDuplicates()` in `notifier/github/comment.go` does not work well with this config.
