### PR TITLE
Correct CODEOWNERS to refer @b4b4r07

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # https://help.github.com/articles/about-codeowners/
-* @b4b4r07
-* @dtan4
+* @b4b4r07 @dtan4


### PR DESCRIPTION
## WHAT

Correct CODEOWNERS to refer both @dtan4 and @b4b4r07 

## WHY

Following to [the current CODEOWNERS settings](https://github.com/mercari/tfnotify/blob/8bac913495b5b449ea012c999c7673f63f95f934/.github/CODEOWNERS), only @dtan4 is assigned as default reviewer.

To assign multiple members, they need to be written in the same line.

https://help.github.com/articles/about-codeowners/

```
# These owners will be the default owners for everything in
# the repo. Unless a later match takes precedence,
# @global-owner1 and @global-owner2 will be requested for
# review when someone opens a pull request.
*       @global-owner1 @global-owner2
```
