### PR TITLE
Update golint's import path

### DIFF
--- a/misc/scripts/install-devel-deps.sh
+++ b/misc/scripts/install-devel-deps.sh
@@ -6,7 +6,7 @@ go get -v -u github.com/Songmu/ghch/cmd/ghch
 go get -v -u github.com/Songmu/goxz/cmd/goxz
 go get -v -u github.com/git-chglog/git-chglog/cmd/git-chglog
 go get -v -u github.com/golang/dep/cmd/dep
-go get -v -u github.com/golang/lint/golint
+go get -v -u golang.org/x/lint/golint
 go get -v -u github.com/haya14busa/goverage
 go get -v -u github.com/haya14busa/reviewdog/cmd/reviewdog
 go get -v -u github.com/motemen/gobump/cmd/gobump


### PR DESCRIPTION
## WHAT

Update golint's import path in `misc/scripts/install-devel-deps.sh` to install golint successfully.

## WHY

Current `misc/scripts/install-devel-deps.sh` fails with the following error:

```
package github.com/golang/lint/golint: code in directory /Users/dtan4/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```

[golint's README](https://github.com/golang/lint) shows that the correct import path is `golang.org/x/lint/golint`.

```bash
go get -u golang.org/x/lint/golint
```