### PR TITLE
Fix test

### DIFF
--- a/notifier/typetalk/client_test.go
+++ b/notifier/typetalk/client_test.go
@@ -39,7 +39,7 @@ func TestNewClient(t *testing.T) {
 			// specify via env but not to be set env (part 2)
 			config:   Config{Token: "$TYPETALK_TOKEN", TopicID: "12345"},
 			envToken: "",
-			expect:   "typetalk token is missing",
+			expect:   "Typetalk token is missing",
 		},
 		{
 			// specify via env (part 2)


### PR DESCRIPTION
Fixed following the error. 🙏 

```
--- FAIL: TestNewClient (0.00s)
	client_test.go:70: got "Typetalk token is missing" but want "typetalk token is missing"
```