### PR TITLE
Update template examples to fix #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,22 +103,24 @@ terraform:
       {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
       {{ .Message }}
       {{if .Result}}
-      <pre><code> {{ .Result }}
+      <pre><code>{{ .Result }}
       </pre></code>
       {{end}}
       <details><summary>Details (Click me)</summary>
-      <pre><code> {{ .Body }}
+
+      <pre><code>{{ .Body }}
       </pre></code></details>
   apply:
     template: |
       {{ .Title }}
       {{ .Message }}
       {{if .Result}}
-      <pre><code> {{ .Result }}
+      <pre><code>{{ .Result }}
       </pre></code>
       {{end}}
       <details><summary>Details (Click me)</summary>
-      <pre><code> {{ .Body }}
+
+      <pre><code>{{ .Body }}
       </pre></code></details>
 ```
 
@@ -152,22 +154,24 @@ terraform:
       {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
       {{ .Message }}
       {{if .Result}}
-      <pre><code> {{ .Result }}
+      <pre><code>{{ .Result }}
       </pre></code>
       {{end}}
       <details><summary>Details (Click me)</summary>
-      <pre><code> {{ .Body }}
+
+      <pre><code>{{ .Body }}
       </pre></code></details>
   apply:
     template: |
       {{ .Title }}
       {{ .Message }}
       {{if .Result}}
-      <pre><code> {{ .Result }}
+      <pre><code>{{ .Result }}
       </pre></code>
       {{end}}
       <details><summary>Details (Click me)</summary>
-      <pre><code> {{ .Body }}
+
+      <pre><code>{{ .Body }}
       </pre></code></details>
 ```
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,7 +50,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code> {{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n<pre><code> {{ .Body }}\n</pre></code></details>\n",
+						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 					},
 					Apply: Apply{
 						Template: "",
@@ -90,7 +90,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code> {{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n<pre><code> {{ .Body }}\n</pre></code></details>\n",
+						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 					},
 					Apply: Apply{
 						Template: "",

--- a/example.tfnotify.yaml
+++ b/example.tfnotify.yaml
@@ -11,9 +11,10 @@ terraform:
       {{ .Title }}
       {{ .Message }}
       {{if .Result}}
-      <pre><code> {{ .Result }}
+      <pre><code>{{ .Result }}
       </pre></code>
       {{end}}
       <details><summary>Details (Click me)</summary>
-      <pre><code> {{ .Body }}
+
+      <pre><code>{{ .Body }}
       </pre></code></details>

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -27,6 +27,7 @@ const (
 {{end}}
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>{{ .Body }}
 </code></pre></details>
 `
@@ -54,6 +55,7 @@ const (
 {{end}}
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>{{ .Body }}
 </code></pre></details>
 `
@@ -70,6 +72,7 @@ const (
 {{end}}
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>{{ .Body }}
 </code></pre></details>
 `

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -22,6 +22,7 @@ func TestDefaultTemplateExecute(t *testing.T) {
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>
 </code></pre></details>
 `,
@@ -39,6 +40,7 @@ message
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>
 </code></pre></details>
 `,
@@ -59,6 +61,7 @@ b
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>c
 </code></pre></details>
 `,
@@ -80,6 +83,7 @@ b
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>c
 </code></pre></details>
 `,
@@ -220,6 +224,7 @@ func TestPlanTemplateExecute(t *testing.T) {
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>
 </code></pre></details>
 `,
@@ -243,6 +248,7 @@ message
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>body
 </code></pre></details>
 `,
@@ -263,6 +269,7 @@ message
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>body
 </code></pre></details>
 `,
@@ -283,6 +290,7 @@ message
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>body
 </code></pre></details>
 `,
@@ -328,6 +336,7 @@ func TestApplyTemplateExecute(t *testing.T) {
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>
 </code></pre></details>
 `,
@@ -351,6 +360,7 @@ message
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>body
 </code></pre></details>
 `,
@@ -371,6 +381,7 @@ message
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>body
 </code></pre></details>
 `,
@@ -391,6 +402,7 @@ message
 
 
 <details><summary>Details (Click me)</summary>
+
 <pre><code>body
 </code></pre></details>
 `,


### PR DESCRIPTION
## WHAT

Add an empty line after the `</summary>` tag in the templates.

## WHY

Fix #5 in the templates.

and remove some blanks to clean up outputs (Refer to the screenshot below).

<img width="495" alt="スクリーンショット 2019-08-15 21 37 30" src="https://user-images.githubusercontent.com/4526869/63095092-49317d80-bfa5-11e9-85f0-eaf30e649976.png">
