### PR TITLE
fix that tfnotify fmt reports incorrect result

### DIFF
--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -48,7 +48,7 @@ func NewDefaultParser() *DefaultParser {
 // NewFmtParser is FmtParser initialized with its Regexp
 func NewFmtParser() *FmtParser {
 	return &FmtParser{
-		Fail: regexp.MustCompile(`(?m)^(diff a/)`),
+		Fail: regexp.MustCompile(`(?m)^@@[^@]+@@`),
 	}
 }
 

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 )
 
-const fmtSuccessResult = `
+// terraform fmt -diff=true -write=false (version 0.11.x)
+const fmtFailResult0_11 = `
 google_spanner_database.tf
 diff a/google_spanner_database.tf b/google_spanner_database.tf
 --- /tmp/398669432
@@ -26,6 +27,19 @@ diff a/google_spanner_instance.tf b/google_spanner_instance.tf
  #   num_nodes    = 1
  # }
 +
+`
+
+// terraform fmt -diff=true -write=false (version 0.12.x)
+const fmtFailResult0_12 = `
+versions.tf
+--- old/versions.tf
++++ new/versions.tf
+@@ -1,4 +1,4 @@
+ 
+ terraform {
+-  required_version     = ">= 0.12"
++  required_version = ">= 0.12"
+ }
 `
 
 const planSuccessResult = `
@@ -216,7 +230,16 @@ func TestFmtParserParse(t *testing.T) {
 	}{
 		{
 			name: "diff",
-			body: fmtSuccessResult,
+			body: fmtFailResult0_11,
+			result: ParseResult{
+				Result:   "There is diff in your .tf file (need to be formatted)",
+				ExitCode: 1,
+				Error:    nil,
+			},
+		},
+		{
+			name: "diff",
+			body: fmtFailResult0_12,
 			result: ParseResult{
 				Result:   "There is diff in your .tf file (need to be formatted)",
 				ExitCode: 1,


### PR DESCRIPTION
## WHAT

"diff a / name.tf b / name.tf" line is an extend optional header, so it may not appear in unified diff text.
we should use hunks (@@ -R +R @@ line) to detect errors, because they are parts of diff content.

## WHY

terraform 0.11.x prints "diff a/name.tf b/name.tf" line, and tfnotify detect it.
https://github.com/hashicorp/hcl/blob/8cb6e5b959231cc1119e43259c4a608f9c51a241/hcl/fmtcmd/fmtcmd.go#L80

but, terraform 0.12.x does not print this line, so tfnotify can't detect fmt error.
https://github.com/hashicorp/terraform/commit/dc7f793be9f263de29b5220d9d7664fdca734659#diff-3ea9cc1590f58ec5fdbc03acc5f1c779R159-R166
