### PR TITLE
Enable slack env vars for channel id and bot name

### DIFF
--- a/notifier/slack/client.go
+++ b/notifier/slack/client.go
@@ -12,6 +12,12 @@ import (
 // EnvToken is Slack API Token
 const EnvToken = "SLACK_TOKEN"
 
+// EnvChannelID is Slack channel ID
+const EnvChannelID = "SLACK_CHANNEL_ID"
+
+// EnvBotName is Slack bot name
+const EnvBotName = "SLACK_BOT_NAME"
+
 // Client is a API client for Slack
 type Client struct {
 	*slack.Client
@@ -51,6 +57,19 @@ func NewClient(cfg Config) (*Client, error) {
 	if token == "" {
 		return &Client{}, errors.New("slack token is missing")
 	}
+
+	channel := cfg.Channel
+	channel = strings.TrimPrefix(channel, "$")
+	if channel == EnvChannelID {
+		channel = os.Getenv(EnvChannelID)
+	}
+
+	botname := cfg.Botname
+	botname = strings.TrimPrefix(botname, "$")
+	if botname == EnvBotName {
+		botname = os.Getenv(EnvBotName)
+	}
+
 	client := slack.New(token)
 	c := &Client{
 		Config: cfg,
@@ -60,8 +79,8 @@ func NewClient(cfg Config) (*Client, error) {
 	c.Notify = (*NotifyService)(&c.common)
 	c.API = &Slack{
 		Client:  client,
-		Channel: cfg.Channel,
-		Botname: cfg.Botname,
+		Channel: channel,
+		Botname: botname,
 	}
 	return c, nil
 }


### PR DESCRIPTION
## WHAT
Enable 2 env vars to configure slack channel id and bot name

## WHY
Although the template example for slack in README looks like it is possible to configure channel id and bot name via env vars, these 2 env vars are actually not read.

https://github.com/mercari/tfnotify/blob/master/README.md#template-examples

( It might not be necessary to configure these via env vars. Please close this PR then. )