### PR TITLE
feat(tf,plan): extract action part from terraform plan output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Placeholder | Usage
 ---|---
 `{{ .Title }}` | Like `## Plan result`
 `{{ .Message }}` | A string that can be set from CLI with `--message` option
+`{{ .Action }}` | Using in terraform plan, and matched leading message by parsing like `Terraform will perform the following actions:`
 `{{ .Result }}` | Matched result by parsing like `Plan: 1 to add` or `No changes`
 `{{ .Body }}` | The entire of Terraform execution result
 `{{ .Link }}` | The link of the build page on CI

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -35,7 +35,7 @@ versions.tf
 --- old/versions.tf
 +++ new/versions.tf
 @@ -1,4 +1,4 @@
- 
+
  terraform {
 -  required_version     = ">= 0.12"
 +  required_version = ">= 0.12"
@@ -309,8 +309,22 @@ func TestPlanParserParse(t *testing.T) {
 			result: ParseResult{
 				Result:     "Plan: 1 to add, 0 to change, 0 to destroy.",
 				HasDestroy: false,
-				ExitCode:   0,
-				Error:      nil,
+				Action: `An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  + google_compute_global_address.my_another_project
+      id:         <computed>
+      address:    <computed>
+      ip_version: "IPV4"
+      name:       "my-another-project"
+      project:    "my-project"
+      self_link:  <computed>
+`,
+				ExitCode: 0,
+				Error:    nil,
 			},
 		},
 		{
@@ -353,15 +367,23 @@ func TestPlanParserParse(t *testing.T) {
 			result: ParseResult{
 				Result:     "Plan: 0 to add, 0 to change, 1 to destroy.",
 				HasDestroy: true,
-				ExitCode:   0,
-				Error:      nil,
+				Action: `An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  - destroy
+
+Terraform will perform the following actions:
+
+  - google_project_iam_member.team_platform[2]
+`,
+				ExitCode: 0,
+				Error:    nil,
 			},
 		},
 	}
 	for _, testCase := range testCases {
 		result := NewPlanParser().Parse(testCase.body)
 		if !reflect.DeepEqual(result, testCase.result) {
-			t.Errorf("got %v but want %v", result, testCase.result)
+			t.Errorf("<%s>: got %v but want %v", testCase.name, result, testCase.result)
 		}
 	}
 }

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -104,6 +104,7 @@ type Template interface {
 type CommonTemplate struct {
 	Title        string
 	Message      string
+	Action       string
 	Result       string
 	Body         string
 	Link         string
@@ -261,6 +262,7 @@ func (t *PlanTemplate) Execute() (string, error) {
 		"Title":   t.Title,
 		"Message": t.Message,
 		"Result":  t.Result,
+		"Action":  t.Action,
 		"Body":    t.Body,
 		"Link":    t.Link,
 	}
@@ -279,6 +281,7 @@ func (t *DestroyWarningTemplate) Execute() (string, error) {
 		"Title":   t.Title,
 		"Message": t.Message,
 		"Result":  t.Result,
+		"Action":  t.Action,
 		"Body":    t.Body,
 		"Link":    t.Link,
 	}

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -450,6 +450,17 @@ message
 			},
 			resp: `a-b-c-d`,
 		},
+		{
+			template: `{{ .Title }}-{{ .Message }}-{{ .Action }}-{{ .Result }}-{{ .Body }}`,
+			value: CommonTemplate{
+				Title:   "a",
+				Message: "b",
+				Action:  "action",
+				Result:  "c",
+				Body:    "d",
+			},
+			resp: `a-b-action-c-d`,
+		},
 	}
 	for _, testCase := range testCases {
 		template := NewPlanTemplate(testCase.template)


### PR DESCRIPTION
## WHAT

Extract the action part of terraform plan, to help us to focus on the more important part during code review.

## WHY

Sometimes we found the part about `Refreshing Terraform state in-memory prior to plan`
has too many lines that we do not need to care about in the code review. So make this
change can help us to focus on the action part that terraform plan is.

## DEMO

The `Action` part will be content below:

```hcl
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + google_compute_global_address.my_another_project
      id:         <computed>
      address:    <computed>
      ip_version: "IPV4"
      name:       "my-another-project"
      project:    "my-project"
      self_link:  <computed>
```