### PR TITLE
fix codebuild-ci code to allow sourceVersion not to has prefix "pr/"

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -57,6 +57,9 @@ func codebuild() (ci CI, err error) {
 	if sourceVersion == "" {
 		return ci, nil
 	}
+	if !strings.HasPrefix(sourceVersion,"pr/") {
+		return ci, nil
+	}
 	pr := strings.Replace(sourceVersion, "pr/", "", 1)
 	if pr == "" {
 		return ci, nil

--- a/ci_test.go
+++ b/ci_test.go
@@ -357,6 +357,21 @@ func TestCodeBuild(t *testing.T) {
 			},
 			ok: false,
 		},
+		{
+			fn: func() {
+				os.Setenv("CODEBUILD_RESOLVED_SOURCE_VERSION", "")
+				os.Setenv("CODEBUILD_SOURCE_VERSION", "f3008ac30d28ac38ae2533c2b153f00041661f22")
+				os.Setenv("CODEBUILD_BUILD_URL", "https://ap-northeast-1.console.aws.amazon.com/codebuild/home?region=ap-northeast-1#/builds/test:f2ae4314-c2d6-4db6-83c2-eacbab1517b7/view/new")
+			},
+			ci: CI{
+				PR: PullRequest{
+					Revision: "",
+					Number:   0,
+				},
+				URL: "https://ap-northeast-1.console.aws.amazon.com/codebuild/home?region=ap-northeast-1#/builds/test:f2ae4314-c2d6-4db6-83c2-eacbab1517b7/view/new",
+			},
+			ok: true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## WHAT

fix codebuild-ci code to allow sourceVersion not to has prefix "pr/"

## WHY
According to https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html, CODEBUILD_SOURCE_VERSION doesn't has prefix "pr/" when trigger is not pull request.

And If we use codebuild as CI and CODEBUILD_SOURCE_VERSION doesn't contain "pr/" , we encounter with error "strconv.Atoi: parsing "xxxxxxxxxxx": invalid syntax "  in tfnotify.

So tfnotify module should check whether sourceVersion has prefix "pr/" or not  and if it doesn't ,return ci and nil before func.strconv.Atoi.
