### PR TITLE
Make it able to notify additionally when the plan result contains destroy operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Placeholder | Usage
 `{{ .Body }}` | The entire of Terraform execution result
 `{{ .Link }}` | The link of the build page on CI
 
+On GitHub, tfnotify can also put a warning message if the plan result contains resource deletion (optional).
+
 #### Template Examples
 
 <details>
@@ -122,6 +124,33 @@ terraform:
 
       <pre><code>{{ .Body }}
       </pre></code></details>
+```
+
+If you would like to let tfnotify warn the resource deletion, add `when_destroy` configuration as below.
+
+```yaml
+---
+# ...
+terraform:
+  # ...
+  plan:
+    template: |
+      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      {{ .Message }}
+      {{if .Result}}
+      <pre><code>{{ .Result }}
+      </pre></code>
+      {{end}}
+      <details><summary>Details (Click me)</summary>
+
+      <pre><code>{{ .Body }}
+      </pre></code></details>
+    when_destroy:
+      template: |
+        ## :warning: WARNING: Resource Deletion will happen :warning:
+
+        This plan contains **resource deletion**. Please check the plan result very carefully!
+  # ...
 ```
 
 </details>

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,12 @@ type Fmt struct {
 
 // Plan is a terraform plan config
 type Plan struct {
+	Template    string      `yaml:"template"`
+	WhenDestroy WhenDestroy `yaml:"when_destroy,omitempty"`
+}
+
+// WhenDestroy is a configuration to notify the plan result contains destroy operation
+type WhenDestroy struct {
 	Template string `yaml:"template"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -102,14 +102,22 @@ func TestLoadFile(t *testing.T) {
 		},
 	}
 
-	var cfg Config
 	for _, testCase := range testCases {
+		var cfg Config
+
 		err := cfg.LoadFile(testCase.file)
-		if !reflect.DeepEqual(cfg, testCase.cfg) {
-			t.Errorf("got %#v but want: %#v", cfg, testCase.cfg)
-		}
-		if (err == nil) != testCase.ok {
-			t.Errorf("got error %q", err)
+		if err == nil {
+			if !testCase.ok {
+				t.Error("got no error but want error")
+			} else {
+				if !reflect.DeepEqual(cfg, testCase.cfg) {
+					t.Errorf("got %#v but want: %#v", cfg, testCase.cfg)
+				}
+			}
+		} else {
+			if testCase.ok {
+				t.Errorf("got error %q but want no error", err)
+			}
 		}
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,13 +50,57 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{
 						Template: "",
 					},
 				},
 				path: "../example.tfnotify.yaml",
+			},
+			ok: true,
+		},
+		{
+			file: "../example-with-destroy.tfnotify.yaml",
+			cfg: Config{
+				CI: "circleci",
+				Notifier: Notifier{
+					Github: GithubNotifier{
+						Token: "$GITHUB_TOKEN",
+						Repository: Repository{
+							Owner: "mercari",
+							Name:  "tfnotify",
+						},
+					},
+					Slack: SlackNotifier{
+						Token:   "",
+						Channel: "",
+						Bot:     "",
+					},
+					Typetalk: TypetalkNotifier{
+						Token:   "",
+						TopicID: "",
+					},
+				},
+				Terraform: Terraform{
+					Default: Default{
+						Template: "",
+					},
+					Fmt: Fmt{
+						Template: "",
+					},
+					Plan: Plan{
+						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						WhenDestroy: WhenDestroy{
+							Template: "## :warning: WARNING: Resource Deletion will happen :warning:\n\nThis plan contains **resource deletion**. Please check the plan result very carefully!\n",
+						},
+					},
+					Apply: Apply{
+						Template: "",
+					},
+				},
+				path: "../example-with-destroy.tfnotify.yaml",
 			},
 			ok: true,
 		},
@@ -90,7 +134,8 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{
 						Template: "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -106,7 +106,7 @@ func TestLoadFile(t *testing.T) {
 	for _, testCase := range testCases {
 		err := cfg.LoadFile(testCase.file)
 		if !reflect.DeepEqual(cfg, testCase.cfg) {
-			t.Errorf("got %q but want %q", cfg, testCase.cfg)
+			t.Errorf("got %#v but want: %#v", cfg, testCase.cfg)
 		}
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)

--- a/example-with-destroy.tfnotify.yaml
+++ b/example-with-destroy.tfnotify.yaml
@@ -1,0 +1,25 @@
+ci: circleci
+notifier:
+  github:
+    token: $GITHUB_TOKEN
+    repository:
+      owner: "mercari"
+      name: "tfnotify"
+terraform:
+  plan:
+    template: |
+      {{ .Title }}
+      {{ .Message }}
+      {{if .Result}}
+      <pre><code>{{ .Result }}
+      </pre></code>
+      {{end}}
+      <details><summary>Details (Click me)</summary>
+
+      <pre><code>{{ .Body }}
+      </pre></code></details>
+    when_destroy:
+      template: |
+        ## :warning: WARNING: Resource Deletion will happen :warning:
+
+        This plan contains **resource deletion**. Please check the plan result very carefully!

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -34,22 +34,29 @@ type Client struct {
 
 // Config is a configuration for GitHub client
 type Config struct {
-	Token    string
-	BaseURL  string
-	Owner    string
-	Repo     string
-	PR       PullRequest
-	CI       string
-	Parser   terraform.Parser
+	Token       string
+	BaseURL     string
+	Owner       string
+	Repo        string
+	PR          PullRequest
+	CI          string
+	Parser      terraform.Parser
+	WarnDestroy bool
+	// Template is used for all Terraform command output
 	Template terraform.Template
+	// DestroyWarningTemplate is used only for additional warning
+	// the plan result contains destroy operation
+	DestroyWarningTemplate terraform.Template
 }
 
 // PullRequest represents GitHub Pull Request metadata
 type PullRequest struct {
-	Revision string
-	Title    string
-	Message  string
-	Number   int
+	Revision              string
+	Title                 string
+	Message               string
+	Number                int
+	DestroyWarningTitle   string
+	DestroyWarningMessage string
 }
 
 type service struct {

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -22,6 +22,16 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 		return result.ExitCode, result.Error
 	}
 
+	_, isPlan := parser.(*terraform.PlanParser)
+	if isPlan {
+		if result.HasDestroy && cfg.WarnDestroy {
+			// Notify destroy warning as a new comment before normal plan result
+			if err = g.notifyDestoryWarning(body, result); err != nil {
+				return result.ExitCode, err
+			}
+		}
+	}
+
 	template.SetValue(terraform.CommonTemplate{
 		Title:   cfg.PR.Title,
 		Message: cfg.PR.Message,
@@ -54,4 +64,29 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 		Number:   cfg.PR.Number,
 		Revision: cfg.PR.Revision,
 	})
+}
+
+func (g *NotifyService) notifyDestoryWarning(body string, result terraform.ParseResult) error {
+	cfg := g.client.Config
+	destroyWarningTemplate := g.client.Config.DestroyWarningTemplate
+	destroyWarningTemplate.SetValue(terraform.CommonTemplate{
+		Title:   cfg.PR.DestroyWarningTitle,
+		Message: cfg.PR.DestroyWarningMessage,
+		Result:  result.Result,
+		Body:    body,
+		Link:    cfg.CI,
+	})
+	body, err := destroyWarningTemplate.Execute()
+	if err != nil {
+		return err
+	}
+
+	if err := g.client.Comment.Post(body, PostOptions{
+		Number:   cfg.PR.Number,
+		Revision: cfg.PR.Revision,
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -81,12 +81,8 @@ func (g *NotifyService) notifyDestoryWarning(body string, result terraform.Parse
 		return err
 	}
 
-	if err := g.client.Comment.Post(body, PostOptions{
+	return g.client.Comment.Post(body, PostOptions{
 		Number:   cfg.PR.Number,
 		Revision: cfg.PR.Revision,
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }

--- a/notifier/github/notify_test.go
+++ b/notifier/github/notify_test.go
@@ -104,6 +104,47 @@ func TestNotifyNotify(t *testing.T) {
 			exitCode: 0,
 		},
 		{
+			// valid, and contains destroy
+			// TODO(dtan4): check two comments were made actually
+			config: Config{
+				Token: "token",
+				Owner: "owner",
+				Repo:  "repo",
+				PR: PullRequest{
+					Revision: "",
+					Number:   1,
+					Message:  "message",
+				},
+				Parser:                 terraform.NewPlanParser(),
+				Template:               terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				DestroyWarningTemplate: terraform.NewDestroyWarningTemplate(terraform.DefaultDestroyWarningTemplate),
+				WarnDestroy:            true,
+			},
+			body:     "Plan: 1 to add, 1 to destroy",
+			ok:       true,
+			exitCode: 0,
+		},
+		{
+			// valid, contains destroy, but not to notify
+			config: Config{
+				Token: "token",
+				Owner: "owner",
+				Repo:  "repo",
+				PR: PullRequest{
+					Revision: "",
+					Number:   1,
+					Message:  "message",
+				},
+				Parser:                 terraform.NewPlanParser(),
+				Template:               terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+				DestroyWarningTemplate: terraform.NewDestroyWarningTemplate(terraform.DefaultDestroyWarningTemplate),
+				WarnDestroy:            false,
+			},
+			body:     "Plan: 1 to add, 1 to destroy",
+			ok:       true,
+			exitCode: 0,
+		},
+		{
 			// apply case
 			config: Config{
 				Token: "token",

--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -60,7 +60,7 @@ func NewPlanParser() *PlanParser {
 		Pass: regexp.MustCompile(`(?m)^(Plan: \d|No changes.)`),
 		Fail: regexp.MustCompile(`(?m)^(Error: )`),
 		// "0 to destroy" should be treated as "no destroy"
-		HasDestroy: regexp.MustCompile(`(?m)([1-9][0-9]* to destroy.)$`),
+		HasDestroy: regexp.MustCompile(`(?m)([1-9][0-9]* to destroy.)`),
 	}
 }
 

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -118,6 +118,50 @@ configuration and real physical resources that exist. As a result, no
 actions need to be performed.
 `
 
+const planHasDestroy = `
+google_bigquery_dataset.tfnotify_echo: Refreshing state...
+google_project.team: Refreshing state...
+pagerduty_team.team: Refreshing state...
+data.pagerduty_vendor.datadog: Refreshing state...
+data.pagerduty_user.service_owner[1]: Refreshing state...
+data.pagerduty_user.service_owner[2]: Refreshing state...
+data.pagerduty_user.service_owner[0]: Refreshing state...
+google_project_services.team: Refreshing state...
+google_project_iam_member.team[1]: Refreshing state...
+google_project_iam_member.team[2]: Refreshing state...
+google_project_iam_member.team[0]: Refreshing state...
+google_project_iam_member.team_platform[1]: Refreshing state...
+google_project_iam_member.team_platform[2]: Refreshing state...
+google_project_iam_member.team_platform[0]: Refreshing state...
+pagerduty_team_membership.team[2]: Refreshing state...
+pagerduty_schedule.secondary: Refreshing state...
+pagerduty_schedule.primary: Refreshing state...
+pagerduty_team_membership.team[0]: Refreshing state...
+pagerduty_team_membership.team[1]: Refreshing state...
+pagerduty_escalation_policy.team: Refreshing state...
+pagerduty_service.team: Refreshing state...
+pagerduty_service_integration.datadog: Refreshing state...
+
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  - destroy
+
+Terraform will perform the following actions:
+
+  - google_project_iam_member.team_platform[2]
+
+
+Plan: 0 to add, 0 to change, 1 to destroy.
+
+------------------------------------------------------------------------
+
+Note: You didn't specify an "-out" parameter to save this plan, so Terraform
+can't guarantee that exactly these actions will be performed if
+"terraform apply" is subsequently run.
+`
+
 const applySuccessResult = `
 data.terraform_remote_state.teams_platform_development: Refreshing state...
 google_project.my_service: Refreshing state...
@@ -251,18 +295,20 @@ func TestPlanParserParse(t *testing.T) {
 			name: "plan ok pattern",
 			body: planSuccessResult,
 			result: ParseResult{
-				Result:   "Plan: 1 to add, 0 to change, 0 to destroy.",
-				ExitCode: 0,
-				Error:    nil,
+				Result:     "Plan: 1 to add, 0 to change, 0 to destroy.",
+				HasDestroy: false,
+				ExitCode:   0,
+				Error:      nil,
 			},
 		},
 		{
 			name: "no stdin",
 			body: "",
 			result: ParseResult{
-				Result:   "",
-				ExitCode: 1,
-				Error:    errors.New("cannot parse plan result"),
+				Result:     "",
+				HasDestroy: false,
+				ExitCode:   1,
+				Error:      errors.New("cannot parse plan result"),
 			},
 		},
 		{
@@ -283,9 +329,20 @@ func TestPlanParserParse(t *testing.T) {
 			name: "plan no changes",
 			body: planNoChanges,
 			result: ParseResult{
-				Result:   "No changes. Infrastructure is up-to-date.",
-				ExitCode: 0,
-				Error:    nil,
+				Result:     "No changes. Infrastructure is up-to-date.",
+				HasDestroy: false,
+				ExitCode:   0,
+				Error:      nil,
+			},
+		},
+		{
+			name: "plan has destroy",
+			body: planHasDestroy,
+			result: ParseResult{
+				Result:     "Plan: 0 to add, 0 to change, 1 to destroy.",
+				HasDestroy: true,
+				ExitCode:   0,
+				Error:      nil,
 			},
 		},
 	}

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -67,6 +67,11 @@ const (
 {{ .Title }}
 
 This plan contains resource delete operation. Please check the plan result very carefully!
+
+{{if .Result}}
+<pre><code>{{ .Result }}
+</code></pre>
+{{end}}
 `
 
 	// DefaultApplyTemplate is a default template for terraform apply

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -12,6 +12,8 @@ const (
 	DefaultFmtTitle = "## Fmt result"
 	// DefaultPlanTitle is a default title for terraform plan
 	DefaultPlanTitle = "## Plan result"
+	// DefaultDestroyWarningTitle is a default title of destroy warning
+	DefaultDestroyWarningTitle = "## WARNING: Resource Deletion will happen"
 	// DefaultApplyTitle is a default title for terraform apply
 	DefaultApplyTitle = "## Apply result"
 
@@ -58,6 +60,13 @@ const (
 
 <pre><code>{{ .Body }}
 </code></pre></details>
+`
+
+	// DefaultDestroyWarningTemplate is a default template for terraform plan
+	DefaultDestroyWarningTemplate = `
+{{ .Title }}
+
+This plan contains resource delete operation. Please check the plan result very carefully!
 `
 
 	// DefaultApplyTemplate is a default template for terraform apply
@@ -115,6 +124,13 @@ type PlanTemplate struct {
 	CommonTemplate
 }
 
+// DestroyWarningTemplate is a default template for warning of destroy operation in plan
+type DestroyWarningTemplate struct {
+	Template string
+
+	CommonTemplate
+}
+
 // ApplyTemplate is a default template for terraform apply
 type ApplyTemplate struct {
 	Template string
@@ -148,6 +164,16 @@ func NewPlanTemplate(template string) *PlanTemplate {
 		template = DefaultPlanTemplate
 	}
 	return &PlanTemplate{
+		Template: template,
+	}
+}
+
+// NewDestroyWarningTemplate is DestroyWarningTemplate initializer
+func NewDestroyWarningTemplate(template string) *DestroyWarningTemplate {
+	if template == "" {
+		template = DefaultDestroyWarningTemplate
+	}
+	return &DestroyWarningTemplate{
 		Template: template,
 	}
 }
@@ -222,6 +248,26 @@ func (t *PlanTemplate) Execute() (resp string, err error) {
 	return resp, err
 }
 
+// Execute binds the execution result of terraform plan into template
+func (t *DestroyWarningTemplate) Execute() (resp string, err error) {
+	tpl, err := template.New("destroy_warning").Parse(t.Template)
+	if err != nil {
+		return resp, err
+	}
+	var b bytes.Buffer
+	if err := tpl.Execute(&b, map[string]interface{}{
+		"Title":   t.Title,
+		"Message": t.Message,
+		"Result":  t.Result,
+		"Body":    t.Body,
+		"Link":    t.Link,
+	}); err != nil {
+		return resp, err
+	}
+	resp = b.String()
+	return resp, err
+}
+
 // Execute binds the execution result of terraform apply into tepmlate
 func (t *ApplyTemplate) Execute() (resp string, err error) {
 	tpl, err := template.New("apply").Parse(t.Template)
@@ -266,6 +312,14 @@ func (t *PlanTemplate) SetValue(ct CommonTemplate) {
 	t.CommonTemplate = ct
 }
 
+// SetValue sets template entities about destroy warning to CommonTemplate
+func (t *DestroyWarningTemplate) SetValue(ct CommonTemplate) {
+	if ct.Title == "" {
+		ct.Title = DefaultDestroyWarningTitle
+	}
+	t.CommonTemplate = ct
+}
+
 // SetValue sets template entities about terraform apply to CommonTemplate
 func (t *ApplyTemplate) SetValue(ct CommonTemplate) {
 	if ct.Title == "" {
@@ -286,6 +340,11 @@ func (t *FmtTemplate) GetValue() CommonTemplate {
 
 // GetValue gets template entities
 func (t *PlanTemplate) GetValue() CommonTemplate {
+	return t.CommonTemplate
+}
+
+// GetValue gets template entities
+func (t *DestroyWarningTemplate) GetValue() CommonTemplate {
 	return t.CommonTemplate
 }
 

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -332,28 +332,53 @@ func TestDestroyWarningTemplateExecute(t *testing.T) {
 ## WARNING: Resource Deletion will happen
 
 This plan contains resource delete operation. Please check the plan result very carefully!
+
+
 `,
 		},
 		{
 			template: DefaultDestroyWarningTemplate,
 			value: CommonTemplate{
-				Title: "title",
+				Title:  "title",
+				Result: "result",
 			},
 			resp: `
 title
 
 This plan contains resource delete operation. Please check the plan result very carefully!
+
+
+<pre><code>result
+</code></pre>
+
+`,
+		},
+		{
+			template: DefaultDestroyWarningTemplate,
+			value: CommonTemplate{
+				Title:  "title",
+				Result: "",
+			},
+			resp: `
+title
+
+This plan contains resource delete operation. Please check the plan result very carefully!
+
+
 `,
 		},
 		{
 			template: "",
 			value: CommonTemplate{
-				Title: "title",
+				Title:  "title",
+				Result: "",
 			},
 			resp: `
 title
 
 This plan contains resource delete operation. Please check the plan result very carefully!
+
+
 `,
 		},
 		{

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -319,6 +319,67 @@ message
 	}
 }
 
+func TestDestroyWarningTemplateExecute(t *testing.T) {
+	testCases := []struct {
+		template string
+		value    CommonTemplate
+		resp     string
+	}{
+		{
+			template: DefaultDestroyWarningTemplate,
+			value:    CommonTemplate{},
+			resp: `
+## WARNING: Resource Deletion will happen
+
+This plan contains resource delete operation. Please check the plan result very carefully!
+`,
+		},
+		{
+			template: DefaultDestroyWarningTemplate,
+			value: CommonTemplate{
+				Title: "title",
+			},
+			resp: `
+title
+
+This plan contains resource delete operation. Please check the plan result very carefully!
+`,
+		},
+		{
+			template: "",
+			value: CommonTemplate{
+				Title: "title",
+			},
+			resp: `
+title
+
+This plan contains resource delete operation. Please check the plan result very carefully!
+`,
+		},
+		{
+			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
+			value: CommonTemplate{
+				Title:   "a",
+				Message: "b",
+				Result:  "c",
+				Body:    "d",
+			},
+			resp: `a-b-c-d`,
+		},
+	}
+	for _, testCase := range testCases {
+		template := NewDestroyWarningTemplate(testCase.template)
+		template.SetValue(testCase.value)
+		resp, err := template.Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp != testCase.resp {
+			t.Errorf("got %q but want %q", resp, testCase.resp)
+		}
+	}
+}
+
 func TestApplyTemplateExecute(t *testing.T) {
 	testCases := []struct {
 		template string


### PR DESCRIPTION
## WHAT

This Pull Request enables tfnotify to comment warning message in addition to the normal plan message when the plan result contains destroy operation.

This feature supports both Terraform 0.11 or below and Terraform 0.12+. Currently, this feature is available on GitHub only.

Here is an example image. Since the plan result tells us Terraform will delete 12 resources, tfnotify warns it in addition to the normal plan comment.

![image](https://user-images.githubusercontent.com/680124/68358324-8b5cfc00-015b-11ea-9f33-7275fbebb844.png)

### Configuration

This is an opt-in feature. When users add `when_destroy` configuration to their `tfnotify.yaml`, tfnotify will warn destroy operation. Without `when_destroy`, tfnotify will NOT warn it as well as the current version.

```yaml
terraform:
  plan:
    template: |
      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
      {{ .Message }}
      {{if .Result}}
      <pre><code> {{ .Result }}
      </pre></code>
      {{end}}
      <details><summary>Details (Click me)</summary>
      <pre><code> {{ .Body }}
      </pre></code></details>      
    when_destroy:
      template: |
        ## :warning: Resource Deletion will happen :warning:

        This plan contains **resource deletion operation**. Please check the plan result very carefully!!!
        {{ .Link }}

        {{if .Result}}
        <pre><code> {{ .Result }}
        </pre></code>
        {{end}}
```

## WHY

The main motivation of this feature is making users aware of the plan result more, especially for destroy operation.

Compared to other Terraform operations such as "adding resources" and "modifying resources", "deleting resources" is much critical. It may affect the customer-facing service and take a long time to recover the original state due to the cloud provider's limitation.

With the current normal plan message, users sometimes miss the plan result even if it contains unexpected operations. As a Terraform repository admin, we should encourage users to look the plan result carefully. This destroy warning message will help it.