### PR TITLE
Install the latest reviewdog binary directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ devel-deps:
 	@go get -v -u github.com/golang/dep/cmd/dep
 	@go get -v -u golang.org/x/lint/golint
 	@go get -v -u github.com/haya14busa/goverage
-	@go get -v -u github.com/haya14busa/reviewdog/cmd/reviewdog
 	@go get -v -u github.com/motemen/gobump/cmd/gobump
 	@go get -v -u github.com/tcnksm/ghr
+	@curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $(go env GOPATH)/bin
 
 .PHONY: dep
 dep: devel-deps


### PR DESCRIPTION
## WHAT

Install the latest reviewdog binary directly instead of building a binary by ourselves using `go get`

## WHY

Now an error is occurred in CI jobs during reviewdog installation.
https://github.com/mercari/tfnotify/pull/52#issuecomment-550692690

This might be fixed by upgrading dependencies, but it's not merged to master branch yet.

https://github.com/reviewdog/reviewdog/pulls

![image](https://user-images.githubusercontent.com/680124/68371589-60d26980-0182-11ea-93c8-d0c450e0d13e.png)

What we really want to do is just using reviewdog binary, not building reviewdog binary at all times. Instead of building binary and seeing error, just downloading a pre-built binary and use it is enough for us.

## REF

- [reviewdog/reviewdog - Installation](https://github.com/reviewdog/reviewdog#installation)