### PR TITLE
Change github comment API

### DIFF
--- a/notifier/github/comment.go
+++ b/notifier/github/comment.go
@@ -21,10 +21,10 @@ type PostOptions struct {
 // Post posts comment
 func (g *CommentService) Post(body string, opt PostOptions) error {
 	if opt.Number != 0 {
-		_, _, err := g.client.API.IssuesCreateComment(
+		_, _, err := g.client.API.PullRequestsCreateComment(
 			context.Background(),
 			opt.Number,
-			&github.IssueComment{Body: &body},
+			&github.PullRequestComment{Body: &body},
 		)
 		return err
 	}
@@ -39,19 +39,19 @@ func (g *CommentService) Post(body string, opt PostOptions) error {
 	return fmt.Errorf("github.comment.post: Number or Revision is required")
 }
 
-// List lists comments on GitHub issues/pull requests
-func (g *CommentService) List(number int) ([]*github.IssueComment, error) {
-	comments, _, err := g.client.API.IssuesListComments(
+// List lists comments on GitHub pull requests
+func (g *CommentService) List(number int) ([]*github.PullRequestComment, error) {
+	comments, _, err := g.client.API.PullRequestsListComments(
 		context.Background(),
 		number,
-		&github.IssueListCommentsOptions{},
+		&github.PullRequestListCommentsOptions{},
 	)
 	return comments, err
 }
 
-// Delete deletes comment on GitHub issues/pull requests
+// Delete deletes comment on GitHub pull requests
 func (g *CommentService) Delete(id int) error {
-	_, err := g.client.API.IssuesDeleteComment(
+	_, err := g.client.API.PullRequestsDeleteComment(
 		context.Background(),
 		int64(id),
 	)
@@ -71,8 +71,8 @@ func (g *CommentService) DeleteDuplicates(title string) {
 	}
 }
 
-func (g *CommentService) getDuplicates(title string) []*github.IssueComment {
-	var dup []*github.IssueComment
+func (g *CommentService) getDuplicates(title string) []*github.PullRequestComment {
+	var dup []*github.PullRequestComment
 	re := regexp.MustCompile(`(?m)^(\n+)?` + title + `( +.*)?\n+` + g.client.Config.PR.Message + `\n+`)
 
 	comments, _ := g.client.Comment.List(g.client.Config.PR.Number)

--- a/notifier/github/comment_test.go
+++ b/notifier/github/comment_test.go
@@ -68,13 +68,13 @@ func TestCommentPost(t *testing.T) {
 }
 
 func TestCommentList(t *testing.T) {
-	comments := []*github.IssueComment{
-		&github.IssueComment{
-			ID:   github.Int64(371748792),
+	comments := []*github.PullRequestComment{
+		&github.PullRequestComment{
+			ID:   github.Int64(471748792),
 			Body: github.String("comment 1"),
 		},
-		&github.IssueComment{
-			ID:   github.Int64(371765743),
+		&github.PullRequestComment{
+			ID:   github.Int64(471765743),
 			Body: github.String("comment 2"),
 		},
 	}
@@ -82,7 +82,7 @@ func TestCommentList(t *testing.T) {
 		config   Config
 		number   int
 		ok       bool
-		comments []*github.IssueComment
+		comments []*github.PullRequestComment
 	}{
 		{
 			config:   newFakeConfig(),
@@ -160,23 +160,23 @@ func TestCommentDelete(t *testing.T) {
 
 func TestCommentGetDuplicates(t *testing.T) {
 	api := newFakeAPI()
-	api.FakeIssuesListComments = func(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error) {
-		var comments []*github.IssueComment
-		comments = []*github.IssueComment{
-			&github.IssueComment{
-				ID:   github.Int64(371748792),
+	api.FakePullRequestsListComments = func(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error) {
+		var comments []*github.PullRequestComment
+		comments = []*github.PullRequestComment{
+			&github.PullRequestComment{
+				ID:   github.Int64(471748792),
 				Body: github.String("## Plan result\nfoo message\n"),
 			},
-			&github.IssueComment{
-				ID:   github.Int64(371765743),
+			&github.PullRequestComment{
+				ID:   github.Int64(471765743),
 				Body: github.String("## Plan result\nbar message\n"),
 			},
-			&github.IssueComment{
-				ID:   github.Int64(371765744),
+			&github.PullRequestComment{
+				ID:   github.Int64(471765744),
 				Body: github.String("## Plan result\nbaz message\n"),
 			},
-			&github.IssueComment{
-				ID:   github.Int64(371765745),
+			&github.PullRequestComment{
+				ID:   github.Int64(471765745),
 				Body: github.String("## Plan result <build URL>\nbaz message\n"),
 			},
 		}
@@ -186,14 +186,14 @@ func TestCommentGetDuplicates(t *testing.T) {
 	testCases := []struct {
 		title    string
 		message  string
-		comments []*github.IssueComment
+		comments []*github.PullRequestComment
 	}{
 		{
 			title:   "## Plan result",
 			message: "foo message",
-			comments: []*github.IssueComment{
-				&github.IssueComment{
-					ID:   github.Int64(371748792),
+			comments: []*github.PullRequestComment{
+				&github.PullRequestComment{
+					ID:   github.Int64(471748792),
 					Body: github.String("## Plan result\nfoo message\n"),
 				},
 			},
@@ -206,13 +206,13 @@ func TestCommentGetDuplicates(t *testing.T) {
 		{
 			title:   "## Plan result",
 			message: "baz message",
-			comments: []*github.IssueComment{
-				&github.IssueComment{
-					ID:   github.Int64(371765744),
+			comments: []*github.PullRequestComment{
+				&github.PullRequestComment{
+					ID:   github.Int64(471765744),
 					Body: github.String("## Plan result\nbaz message\n"),
 				},
-				&github.IssueComment{
-					ID:   github.Int64(371765745),
+				&github.PullRequestComment{
+					ID:   github.Int64(471765745),
 					Body: github.String("## Plan result <build URL>\nbaz message\n"),
 				},
 			},

--- a/notifier/github/github.go
+++ b/notifier/github/github.go
@@ -8,9 +8,9 @@ import (
 
 // API is GitHub API interface
 type API interface {
+	PullRequestsCreateComment(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error)
 	PullRequestsDeleteComment(ctx context.Context, commentID int64) (*github.Response, error)
 	PullRequestsListComments(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error)
-	PullRequestsCreateComment(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error)
 	IssuesDeleteComment(ctx context.Context, commentID int64) (*github.Response, error)
 	IssuesListComments(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
 	IssuesCreateComment(ctx context.Context, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
@@ -24,19 +24,19 @@ type GitHub struct {
 	owner, repo string
 }
 
+// PullRequestsCreateComment is a wrapper of https://godoc.org/github.com/google/go-github/github#PullRequestsService.CreateComment
+func (g *GitHub) PullRequestsCreateComment(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error) {
+	return g.Client.PullRequests.CreateComment(ctx, g.owner, g.repo, number, comment)
+}
+
 // PullRequestsDeleteComment is a wrapper of https://godoc.org/github.com/google/go-github/github#PullRequestsService.DeleteComment
 func (g *GitHub) PullRequestsDeleteComment(ctx context.Context, commentID int64) (*github.Response, error) {
-	return g.Client.PullRequests.CreateComment(ctx, g.owner, g.repo, number, comment)
+	return g.Client.PullRequests.DeleteComment(ctx, g.owner, g.repo, int64(commentID))
 }
 
 // PullRequestsListComments is a wrapper of https://godoc.org/github.com/google/go-github/github#PullRequestsService.ListComments
 func (g *GitHub) PullRequestsListComments(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error) {
 	return g.Client.PullRequests.ListComments(ctx, g.owner, g.repo, number, opt)
-}
-
-// PullRequestsCreateComment is a wrapper of https://godoc.org/github.com/google/go-github/github#PullRequestsService.CreateComment
-func (g *GitHub) PullRequestsCreateComment(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error) {
-	return g.Client.PullRequests.CreateComment(ctx, g.owner, g.repo, number, comment)
 }
 
 // IssuesCreateComment is a wrapper of https://godoc.org/github.com/google/go-github/github#IssuesService.CreateComment

--- a/notifier/github/github.go
+++ b/notifier/github/github.go
@@ -8,9 +8,12 @@ import (
 
 // API is GitHub API interface
 type API interface {
-	IssuesCreateComment(ctx context.Context, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
+	PullRequestsDeleteComment(ctx context.Context, commentID int64) (*github.Response, error)
+	PullRequestsListComments(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error)
+	PullRequestsCreateComment(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error)
 	IssuesDeleteComment(ctx context.Context, commentID int64) (*github.Response, error)
 	IssuesListComments(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
+	IssuesCreateComment(ctx context.Context, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
 	RepositoriesCreateComment(ctx context.Context, sha string, comment *github.RepositoryComment) (*github.RepositoryComment, *github.Response, error)
 	RepositoriesListCommits(ctx context.Context, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
 }
@@ -19,6 +22,21 @@ type API interface {
 type GitHub struct {
 	*github.Client
 	owner, repo string
+}
+
+// PullRequestsDeleteComment is a wrapper of https://godoc.org/github.com/google/go-github/github#PullRequestsService.DeleteComment
+func (g *GitHub) PullRequestsDeleteComment(ctx context.Context, commentID int64) (*github.Response, error) {
+	return g.Client.PullRequests.CreateComment(ctx, g.owner, g.repo, number, comment)
+}
+
+// PullRequestsListComments is a wrapper of https://godoc.org/github.com/google/go-github/github#PullRequestsService.ListComments
+func (g *GitHub) PullRequestsListComments(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error) {
+	return g.Client.PullRequests.ListComments(ctx, g.owner, g.repo, number, opt)
+}
+
+// PullRequestsCreateComment is a wrapper of https://godoc.org/github.com/google/go-github/github#PullRequestsService.CreateComment
+func (g *GitHub) PullRequestsCreateComment(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error) {
+	return g.Client.PullRequests.CreateComment(ctx, g.owner, g.repo, number, comment)
 }
 
 // IssuesCreateComment is a wrapper of https://godoc.org/github.com/google/go-github/github#IssuesService.CreateComment

--- a/notifier/github/github_test.go
+++ b/notifier/github/github_test.go
@@ -39,7 +39,7 @@ func (g *fakeAPI) PullRequestsDeleteComment(ctx context.Context, commentID int64
 	return g.FakePullRequestsDeleteComment(ctx, commentID)
 }
 
-func (g *fakeAPI) PullRequestsListComments(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestsComment, *github.Response, error) {
+func (g *fakeAPI) PullRequestsListComments(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error) {
 	return g.FakePullRequestsListComments(ctx, number, opt)
 }
 

--- a/notifier/github/github_test.go
+++ b/notifier/github/github_test.go
@@ -12,6 +12,9 @@ type fakeAPI struct {
 	FakeIssuesCreateComment       func(ctx context.Context, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
 	FakeIssuesDeleteComment       func(ctx context.Context, commentID int64) (*github.Response, error)
 	FakeIssuesListComments        func(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
+	FakePullRequestsCreateComment func(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error)
+	FakePullRequestsDeleteComment func(ctx context.Context, commentID int64) (*github.Response, error)
+	FakePullRequestsListComments  func(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error)
 	FakeRepositoriesCreateComment func(ctx context.Context, sha string, comment *github.RepositoryComment) (*github.RepositoryComment, *github.Response, error)
 	FakeRepositoriesListCommits   func(ctx context.Context, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
 }
@@ -26,6 +29,18 @@ func (g *fakeAPI) IssuesDeleteComment(ctx context.Context, commentID int64) (*gi
 
 func (g *fakeAPI) IssuesListComments(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error) {
 	return g.FakeIssuesListComments(ctx, number, opt)
+}
+
+func (g *fakeAPI) PullRequestsCreateComment(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error) {
+	return g.FakePullRequestsCreateComment(ctx, number, comment)
+}
+
+func (g *fakeAPI) PullRequestsDeleteComment(ctx context.Context, commentID int64) (*github.Response, error) {
+	return g.FakePullRequestsDeleteComment(ctx, commentID)
+}
+
+func (g *fakeAPI) PullRequestsListComments(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestsComment, *github.Response, error) {
+	return g.FakePullRequestsListComments(ctx, number, opt)
 }
 
 func (g *fakeAPI) RepositoriesCreateComment(ctx context.Context, sha string, comment *github.RepositoryComment) (*github.RepositoryComment, *github.Response, error) {
@@ -56,6 +71,29 @@ func newFakeAPI() fakeAPI {
 				},
 				&github.IssueComment{
 					ID:   github.Int64(371765743),
+					Body: github.String("comment 2"),
+				},
+			}
+			return comments, nil, nil
+		},
+		FakePullRequestsCreateComment: func(ctx context.Context, number int, comment *github.PullRequestComment) (*github.PullRequestComment, *github.Response, error) {
+			return &github.PullRequestComment{
+				ID:   github.Int64(471748792),
+				Body: github.String("comment 1"),
+			}, nil, nil
+		},
+		FakePullRequestsDeleteComment: func(ctx context.Context, commentID int64) (*github.Response, error) {
+			return nil, nil
+		},
+		FakePullRequestsListComments: func(ctx context.Context, number int, opt *github.PullRequestListCommentsOptions) ([]*github.PullRequestComment, *github.Response, error) {
+			var comments []*github.PullRequestComment
+			comments = []*github.PullRequestComment{
+				&github.PullRequestComment{
+					ID:   github.Int64(471748792),
+					Body: github.String("comment 1"),
+				},
+				&github.PullRequestComment{
+					ID:   github.Int64(471765743),
 					Body: github.String("comment 2"),
 				},
 			}


### PR DESCRIPTION
## WHAT

- Delete, List, Add comment with Github PullRequest API.

## WHY

- Github Issue API does not List and Delete duplicated comment for commit.
