### PR TITLE
Add a option to disable HTML escape for Terraform command output in GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,35 @@ terraform:
   # ...
 ```
 
+Sometimes you may want not to HTML-escape Terraform command outputs.
+For example, when you use use code block to print command output, it's better to use raw characters instead of character references (e.g. `-/+` -> `-/&#43;`, `"` -> `&#34;`).
+
+You can disable HTML escape by adding `use_raw_output: true` configuration.
+With this configuration, Terraform doesn't HTML-escape any Terraform output.
+
+~~~yaml
+---
+# ...
+terraform:
+  use_raw_output: true
+  # ...
+  plan:
+    template: |
+      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      {{ .Message }}
+      {{if .Result}}
+      ```
+      {{ .Result }}
+      ```
+      {{end}}
+      <details><summary>Details (Click me)</summary>
+
+      ```
+      {{ .Body }}
+      ```
+  # ...
+~~~
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ terraform:
 ```
 
 Sometimes you may want not to HTML-escape Terraform command outputs.
-For example, when you use use code block to print command output, it's better to use raw characters instead of character references (e.g. `-/+` -> `-/&#43;`, `"` -> `&#34;`).
+For example, when you use code block to print command output, it's better to use raw characters instead of character references (e.g. `-/+` -> `-/&#43;`, `"` -> `&#34;`).
 
 You can disable HTML escape by adding `use_raw_output: true` configuration.
 With this configuration, Terraform doesn't HTML-escape any Terraform output.

--- a/config/config.go
+++ b/config/config.go
@@ -62,10 +62,11 @@ type TypetalkNotifier struct {
 
 // Terraform represents terraform configurations
 type Terraform struct {
-	Default Default `yaml:"default"`
-	Fmt     Fmt     `yaml:"fmt"`
-	Plan    Plan    `yaml:"plan"`
-	Apply   Apply   `yaml:"apply"`
+	Default      Default `yaml:"default"`
+	Fmt          Fmt     `yaml:"fmt"`
+	Plan         Plan    `yaml:"plan"`
+	Apply        Apply   `yaml:"apply"`
+	UseRawOutput bool    `yaml:"use_raw_output,omitempty"`
 }
 
 // Default is a default setting for terraform commands

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,6 +56,7 @@ func TestLoadFile(t *testing.T) {
 					Apply: Apply{
 						Template: "",
 					},
+					UseRawOutput: false,
 				},
 				path: "../example.tfnotify.yaml",
 			},
@@ -99,6 +100,7 @@ func TestLoadFile(t *testing.T) {
 					Apply: Apply{
 						Template: "",
 					},
+					UseRawOutput: false,
 				},
 				path: "../example-with-destroy.tfnotify.yaml",
 			},

--- a/example-use-raw-output.tfnotify.yaml
+++ b/example-use-raw-output.tfnotify.yaml
@@ -1,0 +1,21 @@
+ci: circleci
+notifier:
+  github:
+    token: $GITHUB_TOKEN
+    repository:
+      owner: "mercari"
+      name: "tfnotify"
+terraform:
+  use_raw_output: true
+  plan:
+    template: |
+      {{ .Title }}
+      {{ .Message }}
+      {{if .Result}}
+      <pre><code>{{ .Result }}
+      </pre></code>
+      {{end}}
+      <details><summary>Details (Click me)</summary>
+
+      <pre><code>{{ .Body }}
+      </pre></code></details>

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func (t *tfnotify) Run() error {
 			},
 			CI:                     ci.URL,
 			Parser:                 t.parser,
+			UseRawOutput:           t.config.Terraform.UseRawOutput,
 			Template:               t.template,
 			DestroyWarningTemplate: t.destroyWarningTemplate,
 			WarnDestroy:            t.warnDestroy,

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -34,14 +34,15 @@ type Client struct {
 
 // Config is a configuration for GitHub client
 type Config struct {
-	Token       string
-	BaseURL     string
-	Owner       string
-	Repo        string
-	PR          PullRequest
-	CI          string
-	Parser      terraform.Parser
-	WarnDestroy bool
+	Token        string
+	BaseURL      string
+	Owner        string
+	Repo         string
+	PR           PullRequest
+	CI           string
+	Parser       terraform.Parser
+	UseRawOutput bool
+	WarnDestroy  bool
 	// Template is used for all Terraform command output
 	Template terraform.Template
 	// DestroyWarningTemplate is used only for additional warning

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -33,11 +33,12 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 	}
 
 	template.SetValue(terraform.CommonTemplate{
-		Title:   cfg.PR.Title,
-		Message: cfg.PR.Message,
-		Result:  result.Result,
-		Body:    body,
-		Link:    cfg.CI,
+		Title:        cfg.PR.Title,
+		Message:      cfg.PR.Message,
+		Result:       result.Result,
+		Body:         body,
+		Link:         cfg.CI,
+		UseRawOutput: cfg.UseRawOutput,
 	})
 	body, err = template.Execute()
 	if err != nil {
@@ -70,11 +71,12 @@ func (g *NotifyService) notifyDestoryWarning(body string, result terraform.Parse
 	cfg := g.client.Config
 	destroyWarningTemplate := g.client.Config.DestroyWarningTemplate
 	destroyWarningTemplate.SetValue(terraform.CommonTemplate{
-		Title:   cfg.PR.DestroyWarningTitle,
-		Message: cfg.PR.DestroyWarningMessage,
-		Result:  result.Result,
-		Body:    body,
-		Link:    cfg.CI,
+		Title:        cfg.PR.DestroyWarningTitle,
+		Message:      cfg.PR.DestroyWarningMessage,
+		Result:       result.Result,
+		Body:         body,
+		Link:         cfg.CI,
+		UseRawOutput: cfg.UseRawOutput,
 	})
 	body, err := destroyWarningTemplate.Execute()
 	if err != nil {

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -195,8 +195,32 @@ func NewApplyTemplate(template string) *ApplyTemplate {
 	}
 }
 
+func generateOutput(kind, template string, data map[string]interface{}, useRawOutput bool) (string, error) {
+	var b bytes.Buffer
+
+	if useRawOutput {
+		tpl, err := texttemplate.New(kind).Parse(template)
+		if err != nil {
+			return "", err
+		}
+		if err := tpl.Execute(&b, data); err != nil {
+			return "", err
+		}
+	} else {
+		tpl, err := htmltemplate.New(kind).Parse(template)
+		if err != nil {
+			return "", err
+		}
+		if err := tpl.Execute(&b, data); err != nil {
+			return "", err
+		}
+	}
+
+	return b.String(), nil
+}
+
 // Execute binds the execution result of terraform command into tepmlate
-func (t *DefaultTemplate) Execute() (resp string, err error) {
+func (t *DefaultTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
@@ -205,32 +229,16 @@ func (t *DefaultTemplate) Execute() (resp string, err error) {
 		"Link":    t.Link,
 	}
 
-	var b bytes.Buffer
-
-	if t.UseRawOutput {
-		tpl, err := texttemplate.New("default").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
-	} else {
-		tpl, err := htmltemplate.New("default").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
+	resp, err := generateOutput("default", t.Template, data, t.UseRawOutput)
+	if err != nil {
+		return "", err
 	}
 
-	resp = b.String()
-	return resp, err
+	return resp, nil
 }
 
 // Execute binds the execution result of terraform fmt into tepmlate
-func (t *FmtTemplate) Execute() (resp string, err error) {
+func (t *FmtTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
@@ -239,34 +247,16 @@ func (t *FmtTemplate) Execute() (resp string, err error) {
 		"Link":    t.Link,
 	}
 
-	var b bytes.Buffer
-
-	if t.UseRawOutput {
-		tpl, err := texttemplate.New("fmt").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
-	} else {
-		tpl, err := htmltemplate.New("fmt").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
+	resp, err := generateOutput("fmt", t.Template, data, t.UseRawOutput)
+	if err != nil {
+		return "", err
 	}
 
-	resp = b.String()
-	return resp, err
+	return resp, nil
 }
 
 // Execute binds the execution result of terraform plan into tepmlate
-func (t *PlanTemplate) Execute() (resp string, err error) {
+func (t *PlanTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
@@ -275,30 +265,12 @@ func (t *PlanTemplate) Execute() (resp string, err error) {
 		"Link":    t.Link,
 	}
 
-	var b bytes.Buffer
-
-	if t.UseRawOutput {
-		tpl, err := texttemplate.New("plan").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
-	} else {
-		tpl, err := htmltemplate.New("plan").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
+	resp, err := generateOutput("plan", t.Template, data, t.UseRawOutput)
+	if err != nil {
+		return "", err
 	}
 
-	resp = b.String()
-	return resp, err
+	return resp, nil
 }
 
 // Execute binds the execution result of terraform plan into template
@@ -322,7 +294,7 @@ func (t *DestroyWarningTemplate) Execute() (resp string, err error) {
 }
 
 // Execute binds the execution result of terraform apply into tepmlate
-func (t *ApplyTemplate) Execute() (resp string, err error) {
+func (t *ApplyTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
@@ -331,30 +303,12 @@ func (t *ApplyTemplate) Execute() (resp string, err error) {
 		"Link":    t.Link,
 	}
 
-	var b bytes.Buffer
-
-	if t.UseRawOutput {
-		tpl, err := texttemplate.New("apply").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
-	} else {
-		tpl, err := htmltemplate.New("apply").Parse(t.Template)
-		if err != nil {
-			return resp, err
-		}
-
-		if err := tpl.Execute(&b, data); err != nil {
-			return resp, err
-		}
+	resp, err := generateOutput("apply", t.Template, data, t.UseRawOutput)
+	if err != nil {
+		return "", err
 	}
 
-	resp = b.String()
-	return resp, err
+	return resp, nil
 }
 
 // SetValue sets template entities to CommonTemplate

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"bytes"
-	"html/template"
+	htmltemplate "html/template"
 )
 
 const (
@@ -196,67 +196,93 @@ func NewApplyTemplate(template string) *ApplyTemplate {
 
 // Execute binds the execution result of terraform command into tepmlate
 func (t *DefaultTemplate) Execute() (resp string, err error) {
-	tpl, err := template.New("default").Parse(t.Template)
-	if err != nil {
-		return resp, err
-	}
-	var b bytes.Buffer
-	if err := tpl.Execute(&b, map[string]interface{}{
+	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
 		"Result":  "",
 		"Body":    t.Result,
 		"Link":    t.Link,
-	}); err != nil {
-		return resp, err
 	}
+
+	var b bytes.Buffer
+
+	if t.UseRawOutput {
+		// do nothing
+	} else {
+		tpl, err := htmltemplate.New("default").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
+	}
+
 	resp = b.String()
 	return resp, err
 }
 
 // Execute binds the execution result of terraform fmt into tepmlate
 func (t *FmtTemplate) Execute() (resp string, err error) {
-	tpl, err := template.New("fmt").Parse(t.Template)
-	if err != nil {
-		return resp, err
-	}
-	var b bytes.Buffer
-	if err := tpl.Execute(&b, map[string]interface{}{
+	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
 		"Result":  "",
 		"Body":    t.Result,
 		"Link":    t.Link,
-	}); err != nil {
-		return resp, err
 	}
+
+	var b bytes.Buffer
+
+	if t.UseRawOutput {
+		// do nothing
+	} else {
+		tpl, err := htmltemplate.New("fmt").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
+	}
+
 	resp = b.String()
 	return resp, err
 }
 
 // Execute binds the execution result of terraform plan into tepmlate
 func (t *PlanTemplate) Execute() (resp string, err error) {
-	tpl, err := template.New("plan").Parse(t.Template)
-	if err != nil {
-		return resp, err
-	}
-	var b bytes.Buffer
-	if err := tpl.Execute(&b, map[string]interface{}{
+	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
 		"Result":  t.Result,
 		"Body":    t.Body,
 		"Link":    t.Link,
-	}); err != nil {
-		return resp, err
 	}
+
+	var b bytes.Buffer
+
+	if t.UseRawOutput {
+		// do nothing
+	} else {
+		tpl, err := htmltemplate.New("plan").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
+	}
+
 	resp = b.String()
 	return resp, err
 }
 
 // Execute binds the execution result of terraform plan into template
 func (t *DestroyWarningTemplate) Execute() (resp string, err error) {
-	tpl, err := template.New("destroy_warning").Parse(t.Template)
+	tpl, err := htmltemplate.New("destroy_warning").Parse(t.Template)
 	if err != nil {
 		return resp, err
 	}
@@ -276,20 +302,29 @@ func (t *DestroyWarningTemplate) Execute() (resp string, err error) {
 
 // Execute binds the execution result of terraform apply into tepmlate
 func (t *ApplyTemplate) Execute() (resp string, err error) {
-	tpl, err := template.New("apply").Parse(t.Template)
-	if err != nil {
-		return resp, err
-	}
-	var b bytes.Buffer
-	if err := tpl.Execute(&b, map[string]interface{}{
+	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
 		"Result":  t.Result,
 		"Body":    t.Body,
 		"Link":    t.Link,
-	}); err != nil {
-		return resp, err
 	}
+
+	var b bytes.Buffer
+
+	if t.UseRawOutput {
+		// do nothing
+	} else {
+		tpl, err := htmltemplate.New("apply").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
+	}
+
 	resp = b.String()
 	return resp, err
 }

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -101,11 +101,12 @@ type Template interface {
 
 // CommonTemplate represents template entities
 type CommonTemplate struct {
-	Title   string
-	Message string
-	Result  string
-	Body    string
-	Link    string
+	Title        string
+	Message      string
+	Result       string
+	Body         string
+	Link         string
+	UseRawOutput bool
 }
 
 // DefaultTemplate is a default template for terraform commands

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bytes"
 	htmltemplate "html/template"
+	texttemplate "text/template"
 )
 
 const (
@@ -207,7 +208,13 @@ func (t *DefaultTemplate) Execute() (resp string, err error) {
 	var b bytes.Buffer
 
 	if t.UseRawOutput {
-		// do nothing
+		tpl, err := texttemplate.New("default").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
 	} else {
 		tpl, err := htmltemplate.New("default").Parse(t.Template)
 		if err != nil {
@@ -235,7 +242,14 @@ func (t *FmtTemplate) Execute() (resp string, err error) {
 	var b bytes.Buffer
 
 	if t.UseRawOutput {
-		// do nothing
+		tpl, err := texttemplate.New("fmt").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
 	} else {
 		tpl, err := htmltemplate.New("fmt").Parse(t.Template)
 		if err != nil {
@@ -264,7 +278,14 @@ func (t *PlanTemplate) Execute() (resp string, err error) {
 	var b bytes.Buffer
 
 	if t.UseRawOutput {
-		// do nothing
+		tpl, err := texttemplate.New("plan").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
 	} else {
 		tpl, err := htmltemplate.New("plan").Parse(t.Template)
 		if err != nil {
@@ -313,7 +334,14 @@ func (t *ApplyTemplate) Execute() (resp string, err error) {
 	var b bytes.Buffer
 
 	if t.UseRawOutput {
-		// do nothing
+		tpl, err := texttemplate.New("apply").Parse(t.Template)
+		if err != nil {
+			return resp, err
+		}
+
+		if err := tpl.Execute(&b, data); err != nil {
+			return resp, err
+		}
 	} else {
 		tpl, err := htmltemplate.New("apply").Parse(t.Template)
 		if err != nil {

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -274,23 +274,21 @@ func (t *PlanTemplate) Execute() (string, error) {
 }
 
 // Execute binds the execution result of terraform plan into template
-func (t *DestroyWarningTemplate) Execute() (resp string, err error) {
-	tpl, err := htmltemplate.New("destroy_warning").Parse(t.Template)
-	if err != nil {
-		return resp, err
-	}
-	var b bytes.Buffer
-	if err := tpl.Execute(&b, map[string]interface{}{
+func (t *DestroyWarningTemplate) Execute() (string, error) {
+	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
 		"Result":  t.Result,
 		"Body":    t.Body,
 		"Link":    t.Link,
-	}); err != nil {
-		return resp, err
 	}
-	resp = b.String()
-	return resp, err
+
+	resp, err := generateOutput("destroy_warning", t.Template, data, t.UseRawOutput)
+	if err != nil {
+		return "", err
+	}
+
+	return resp, nil
 }
 
 // Execute binds the execution result of terraform apply into tepmlate

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -110,6 +110,50 @@ b
 `,
 		},
 		{
+			template: "",
+			value: CommonTemplate{
+				Title:        "a",
+				Message:      "b",
+				Result:       `This is a "result".`,
+				Body:         "d",
+				UseRawOutput: true,
+			},
+			resp: `
+a
+
+b
+
+
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>This is a "result".
+</code></pre></details>
+`,
+		},
+		{
+			template: "",
+			value: CommonTemplate{
+				Title:        "a",
+				Message:      "b",
+				Result:       `This is a "result".`,
+				Body:         "d",
+				UseRawOutput: true,
+			},
+			resp: `
+a
+
+b
+
+
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>This is a "result".
+</code></pre></details>
+`,
+		},
+		{
 			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
 				Title:   "a",
@@ -223,6 +267,25 @@ This is a &#34;result&#34;.
 `,
 		},
 		{
+			template: "",
+			value: CommonTemplate{
+				Title:        "a",
+				Message:      "b",
+				Result:       `This is a "result".`,
+				Body:         "d",
+				UseRawOutput: true,
+			},
+			resp: `
+a
+
+b
+
+
+
+This is a "result".
+`,
+		},
+		{
 			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
 				Title:   "a",
@@ -331,6 +394,28 @@ message
 <details><summary>Details (Click me)</summary>
 
 <pre><code>This is a &#34;body&#34;.
+</code></pre></details>
+`,
+		},
+		{
+			template: DefaultPlanTemplate,
+			value: CommonTemplate{
+				Title:        "title",
+				Message:      "message",
+				Result:       "",
+				Body:         `This is a "body".`,
+				UseRawOutput: true,
+			},
+			resp: `
+title
+
+message
+
+
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>This is a "body".
 </code></pre></details>
 `,
 		},
@@ -571,6 +656,28 @@ message
 <details><summary>Details (Click me)</summary>
 
 <pre><code>This is a &#34;body&#34;.
+</code></pre></details>
+`,
+		},
+		{
+			template: "",
+			value: CommonTemplate{
+				Title:        "title",
+				Message:      "message",
+				Result:       "",
+				Body:         `This is a "body".`,
+				UseRawOutput: true,
+			},
+			resp: `
+title
+
+message
+
+
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>This is a "body".
 </code></pre></details>
 `,
 		},

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -89,6 +89,27 @@ b
 `,
 		},
 		{
+			template: "",
+			value: CommonTemplate{
+				Title:   "a",
+				Message: "b",
+				Result:  `This is a "result".`,
+				Body:    "d",
+			},
+			resp: `
+a
+
+b
+
+
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>This is a &#34;result&#34;.
+</code></pre></details>
+`,
+		},
+		{
 			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
 				Title:   "a",
@@ -184,6 +205,24 @@ c
 `,
 		},
 		{
+			template: "",
+			value: CommonTemplate{
+				Title:   "a",
+				Message: "b",
+				Result:  `This is a "result".`,
+				Body:    "d",
+			},
+			resp: `
+a
+
+b
+
+
+
+This is a &#34;result&#34;.
+`,
+		},
+		{
 			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
 				Title:   "a",
@@ -271,6 +310,27 @@ message
 <details><summary>Details (Click me)</summary>
 
 <pre><code>body
+</code></pre></details>
+`,
+		},
+		{
+			template: DefaultPlanTemplate,
+			value: CommonTemplate{
+				Title:   "title",
+				Message: "message",
+				Result:  "",
+				Body:    `This is a "body".`,
+			},
+			resp: `
+title
+
+message
+
+
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>This is a &#34;body&#34;.
 </code></pre></details>
 `,
 		},
@@ -490,6 +550,27 @@ message
 <details><summary>Details (Click me)</summary>
 
 <pre><code>body
+</code></pre></details>
+`,
+		},
+		{
+			template: "",
+			value: CommonTemplate{
+				Title:   "title",
+				Message: "message",
+				Result:  "",
+				Body:    `This is a "body".`,
+			},
+			resp: `
+title
+
+message
+
+
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>This is a &#34;body&#34;.
 </code></pre></details>
 `,
 		},

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -624,7 +624,7 @@ func TestGetValue(t *testing.T) {
 		template := testCase.template
 		value := template.GetValue()
 		if !reflect.DeepEqual(value, testCase.expected) {
-			t.Errorf("got %q but want %q", value, testCase.expected)
+			t.Errorf("got %#v but want %#v", value, testCase.expected)
 		}
 	}
 }

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -485,7 +485,7 @@ This plan contains resource delete operation. Please check the plan result very 
 			template: DefaultDestroyWarningTemplate,
 			value: CommonTemplate{
 				Title:  "title",
-				Result: "result",
+				Result: `This is a "result".`,
 			},
 			resp: `
 title
@@ -493,7 +493,25 @@ title
 This plan contains resource delete operation. Please check the plan result very carefully!
 
 
-<pre><code>result
+<pre><code>This is a &#34;result&#34;.
+</code></pre>
+
+`,
+		},
+		{
+			template: DefaultDestroyWarningTemplate,
+			value: CommonTemplate{
+				Title:        "title",
+				Result:       `This is a "result".`,
+				UseRawOutput: true,
+			},
+			resp: `
+title
+
+This plan contains resource delete operation. Please check the plan result very carefully!
+
+
+<pre><code>This is a "result".
 </code></pre>
 
 `,


### PR DESCRIPTION
## WHAT

Add a option `use_raw_output: true` to disable HTML escape for Terraform command output

```yaml
terraform:
  use_raw_output: true # <<<-------
  plan:
    # ...
```

### Example

base configuration

```yaml
ci: circleci
notifier:
  github:
    # ...
terraform:
  plan:
    template: |
      ```
      {{ .Body }}
      ```
```

#### Before (no `use_raw_output`)

![image](https://user-images.githubusercontent.com/680124/71457861-642dbd00-27e3-11ea-9741-d018f346d168.png)

#### After (`use_raw_output: true`)

![image](https://user-images.githubusercontent.com/680124/71457904-9808e280-27e3-11ea-97d6-855ea735a7ad.png)


## WHY

Current tfnotify does HTML escape for all Terraform command outputs forcibly. For example, it replaces some characters to character references (e.g. `-/+` -> `-/&#43;`, `"` -> `&#34;`). However, when we use code blocks to render command outputs in Markdown, these character references are renders as they are. Therefore, the output in GitHub comment becomes weird for human.

We'd like to prevent HTML escape if necessary.