### PR TITLE
Tidy up development dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ devel-deps:
 	@go get -v -u github.com/haya14busa/goverage
 	@go get -v -u github.com/motemen/gobump/cmd/gobump
 	@curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $(go env GOPATH)/bin
+	@curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=$(go env GOPATH)/bin sh
 
 .PHONY: dep
 dep: devel-deps

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ devel-deps:
 	@go get -v -u golang.org/x/lint/golint
 	@go get -v -u github.com/haya14busa/goverage
 	@go get -v -u github.com/motemen/gobump/cmd/gobump
-	@curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $(go env GOPATH)/bin
-	@curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=$(go env GOPATH)/bin sh
+	@curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $$(go env GOPATH)/bin
+	@curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=$$(go env GOPATH)/bin sh
 
 .PHONY: dep
 dep: devel-deps

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,11 @@ test:
 
 .PHONY: devel-deps
 devel-deps:
-	@go get -v -u github.com/Songmu/ghch/cmd/ghch
-	@go get -v -u github.com/Songmu/goxz/cmd/goxz
 	@go get -v -u github.com/git-chglog/git-chglog/cmd/git-chglog
 	@go get -v -u github.com/golang/dep/cmd/dep
 	@go get -v -u golang.org/x/lint/golint
 	@go get -v -u github.com/haya14busa/goverage
 	@go get -v -u github.com/motemen/gobump/cmd/gobump
-	@go get -v -u github.com/tcnksm/ghr
 	@curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $(go env GOPATH)/bin
 
 .PHONY: dep


### PR DESCRIPTION
## WHAT

Tidy up development dependencies

- Remove unused dependencies: `ghch`, `goxz`, and `ghr`
  - They were replaced to GoReleaser, etc. https://github.com/mercari/tfnotify/commit/c6550df46069e323f0660e3565c43da9a860e231
- Add GoReleaser to dependencies
  - GoReleaser is required by [release-go](https://github.com/b4b4r07/release-go)

## WHY

We don't have to install unnecessary tools in every CI build. Additionally, some of them cause failure during installation.
https://github.com/mercari/tfnotify/pull/58#issuecomment-568978843