### PR TITLE
Support branch builds of Travis CI

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -43,9 +43,15 @@ func circleci() (ci CI, err error) {
 }
 
 func travisci() (ci CI, err error) {
-	ci.PR.Revision = os.Getenv("TRAVIS_PULL_REQUEST_SHA")
-	ci.PR.Number, err = strconv.Atoi(os.Getenv("TRAVIS_PULL_REQUEST"))
 	ci.URL = os.Getenv("TRAVIS_BUILD_WEB_URL")
+	prNumber := os.Getenv("TRAVIS_PULL_REQUEST")
+	if prNumber == "false" {
+		ci.PR.Number = 0
+		ci.PR.Revision = os.Getenv("TRAVIS_COMMIT")
+		return ci, nil
+	}
+	ci.PR.Revision = os.Getenv("TRAVIS_PULL_REQUEST_SHA")
+	ci.PR.Number, err = strconv.Atoi(prNumber)
 	return ci, err
 }
 
@@ -57,7 +63,7 @@ func codebuild() (ci CI, err error) {
 	if sourceVersion == "" {
 		return ci, nil
 	}
-	if !strings.HasPrefix(sourceVersion,"pr/") {
+	if !strings.HasPrefix(sourceVersion, "pr/") {
 		return ci, nil
 	}
 	pr := strings.Replace(sourceVersion, "pr/", "", 1)

--- a/ci_test.go
+++ b/ci_test.go
@@ -150,6 +150,7 @@ func TestTravisCI(t *testing.T) {
 	envs := []string{
 		"TRAVIS_PULL_REQUEST_SHA",
 		"TRAVIS_PULL_REQUEST",
+		"TRAVIS_COMMIT",
 	}
 	saveEnvs := make(map[string]string)
 	for _, key := range envs {
@@ -172,6 +173,7 @@ func TestTravisCI(t *testing.T) {
 			fn: func() {
 				os.Setenv("TRAVIS_PULL_REQUEST_SHA", "abcdefg")
 				os.Setenv("TRAVIS_PULL_REQUEST", "1")
+				os.Setenv("TRAVIS_COMMIT", "hijklmn")
 			},
 			ci: CI{
 				PR: PullRequest{
@@ -186,15 +188,16 @@ func TestTravisCI(t *testing.T) {
 			fn: func() {
 				os.Setenv("TRAVIS_PULL_REQUEST_SHA", "abcdefg")
 				os.Setenv("TRAVIS_PULL_REQUEST", "false")
+				os.Setenv("TRAVIS_COMMIT", "hijklmn")
 			},
 			ci: CI{
 				PR: PullRequest{
-					Revision: "abcdefg",
+					Revision: "hijklmn",
 					Number:   0,
 				},
 				URL: "",
 			},
-			ok: false,
+			ok: true,
 		},
 	}
 


### PR DESCRIPTION
## WHAT

This PR allows tfnotify work not only for pull request builds but also for branch builds.

There are two kind of build in Travis CI, branch build (triggered by push to a branch) and pull request build (triggered by push to a branch whose pull request exists).
Only pull request build have `TRAVIS_PULL_REQUEST` and `TRAVIS_PULL_REQUEST_SHA` variables, which tfnotify now uses to find the revisions of builds.
(ref: https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests)

This PR enables tfnotify to find the revisions of branch builds by refering `TRAVIS_COMMIT` variable, that represents the HEAD commit id of the current build. (ref: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)

## WHY

For now, it is inconvenient to use tfnotify on Travis CI because tfnotify does not work on Travis CI builds for  merge commits. (These builds are branch builds.) This PR resolves the problem.

Usual project runs `terraform plan` on each pull request and `terraform apply` when master branch is pushed.
These `plan` builds are run as pull request build but `apply` builds are run as branch builds.

## Working examples

As working examples, I've created a sample project and two pull requests to compare `tfnotify` results. Each pull request runs both pull request build and branch build.

* With original tfnotify: https://github.com/tomoasleep/terraform-sample/pull/2
  * Pull request build succeeded, but branch build failed.
* With modified tfnotify: https://github.com/tomoasleep/terraform-sample/pull/1
  * Both pull request build and branch build succeeded.
