### PR TITLE
Add example for Github Enterprise base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ ci: circleci
 notifier:
   github:
     token: $GITHUB_TOKEN
-    base_url: $GITHUB_BASE_URL
+    base_url: $GITHUB_BASE_URL # Example: https://github.example.com/api/v3
     repository:
       owner: "mercari"
       name: "tfnotify"


### PR DESCRIPTION
## WHAT

Added an example for the `GITHUB_BASE_URL` for Github Enterprise

## WHY

I discovered that the go client requires the base URL to include the `/api/v3` API endpoint for a privately hosted Github Enterprise account. Github Enterprise API endpoints follow the same pattern: `https://{{ hostname }}/api/v3/`