### PR TITLE
try parsing pr number to create apply result comment on merged pr

### DIFF
--- a/notifier/github/commits_test.go
+++ b/notifier/github/commits_test.go
@@ -89,3 +89,49 @@ func TestCommitsLastOne(t *testing.T) {
 		}
 	}
 }
+
+func TestMergedPRNumber(t *testing.T) {
+	testCases := []struct {
+		prNumber int
+		ok       bool
+		revision string
+	}{
+		{
+			prNumber: 1,
+			ok:       true,
+			revision: "Merge pull request #1 from mercari/tfnotify",
+		},
+		{
+			prNumber: 123,
+			ok:       true,
+			revision: "Merge pull request #123 from mercari/tfnotify",
+		},
+		{
+			prNumber: 0,
+			ok:       false,
+			revision: "destroyed the world",
+		},
+		{
+			prNumber: 0,
+			ok:       false,
+			revision: "Merge pull request #string from mercari/tfnotify",
+		},
+	}
+
+	for _, testCase := range testCases {
+		cfg := newFakeConfig()
+		client, err := NewClient(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		api := newFakeAPI()
+		client.API = &api
+		prNumber, err := client.Commits.MergedPRNumber(testCase.revision)
+		if (err == nil) != testCase.ok {
+			t.Errorf("got error %q", err)
+		}
+		if prNumber != testCase.prNumber {
+			t.Errorf("got %q but want %q", prNumber, testCase.prNumber)
+		}
+	}
+}

--- a/notifier/github/github.go
+++ b/notifier/github/github.go
@@ -13,6 +13,7 @@ type API interface {
 	IssuesListComments(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
 	RepositoriesCreateComment(ctx context.Context, sha string, comment *github.RepositoryComment) (*github.RepositoryComment, *github.Response, error)
 	RepositoriesListCommits(ctx context.Context, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
+	RepositoriesGetCommit(ctx context.Context, sha string) (*github.RepositoryCommit, *github.Response, error)
 }
 
 // GitHub represents the attribute information necessary for requesting GitHub API
@@ -44,4 +45,9 @@ func (g *GitHub) RepositoriesCreateComment(ctx context.Context, sha string, comm
 // RepositoriesListCommits is a wrapper of https://godoc.org/github.com/google/go-github/github#RepositoriesService.ListCommits
 func (g *GitHub) RepositoriesListCommits(ctx context.Context, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
 	return g.Client.Repositories.ListCommits(ctx, g.owner, g.repo, opt)
+}
+
+// RepositoriesGetCommit is a wrapper of https://godoc.org/github.com/google/go-github/github#RepositoriesService.GetCommit
+func (g *GitHub) RepositoriesGetCommit(ctx context.Context, sha string) (*github.RepositoryCommit, *github.Response, error) {
+	return g.Client.Repositories.GetCommit(ctx, g.owner, g.repo, sha)
 }

--- a/notifier/github/github_test.go
+++ b/notifier/github/github_test.go
@@ -14,6 +14,7 @@ type fakeAPI struct {
 	FakeIssuesListComments        func(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
 	FakeRepositoriesCreateComment func(ctx context.Context, sha string, comment *github.RepositoryComment) (*github.RepositoryComment, *github.Response, error)
 	FakeRepositoriesListCommits   func(ctx context.Context, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
+	FakeRepositoriesGetCommit     func(ctx context.Context, sha string) (*github.RepositoryCommit, *github.Response, error)
 }
 
 func (g *fakeAPI) IssuesCreateComment(ctx context.Context, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
@@ -34,6 +35,10 @@ func (g *fakeAPI) RepositoriesCreateComment(ctx context.Context, sha string, com
 
 func (g *fakeAPI) RepositoriesListCommits(ctx context.Context, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
 	return g.FakeRepositoriesListCommits(ctx, opt)
+}
+
+func (g *fakeAPI) RepositoriesGetCommit(ctx context.Context, sha string) (*github.RepositoryCommit, *github.Response, error) {
+	return g.FakeRepositoriesGetCommit(ctx, sha)
 }
 
 func newFakeAPI() fakeAPI {
@@ -82,6 +87,14 @@ func newFakeAPI() fakeAPI {
 				},
 			}
 			return commits, nil, nil
+		},
+		FakeRepositoriesGetCommit: func(ctx context.Context, sha string) (*github.RepositoryCommit, *github.Response, error) {
+			return &github.RepositoryCommit{
+				SHA: github.String(sha),
+				Commit: &github.Commit{
+					Message: github.String(sha),
+				},
+			}, nil, nil
 		},
 	}
 }

--- a/notifier/github/notify_test.go
+++ b/notifier/github/notify_test.go
@@ -145,13 +145,32 @@ func TestNotifyNotify(t *testing.T) {
 			exitCode: 0,
 		},
 		{
-			// apply case
+			// apply case without merge commit
 			config: Config{
 				Token: "token",
 				Owner: "owner",
 				Repo:  "repo",
 				PR: PullRequest{
 					Revision: "revision",
+					Number:   0, // For apply, it is always 0
+					Message:  "message",
+				},
+				Parser:   terraform.NewApplyParser(),
+				Template: terraform.NewApplyTemplate(terraform.DefaultApplyTemplate),
+			},
+			body:     "Apply complete!",
+			ok:       true,
+			exitCode: 0,
+		},
+		{
+			// apply case as merge commit
+			// TODO(drlau): validate cfg.PR.Number = 123
+			config: Config{
+				Token: "token",
+				Owner: "owner",
+				Repo:  "repo",
+				PR: PullRequest{
+					Revision: "Merge pull request #123 from mercari/tfnotify",
 					Number:   0, // For apply, it is always 0
 					Message:  "message",
 				},

--- a/notifier/slack/notify.go
+++ b/notifier/slack/notify.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/mercari/tfnotify/terraform"
 	"github.com/lestrrat-go/slack/objects"
+	"github.com/mercari/tfnotify/terraform"
 )
 
 // NotifyService handles communication with the notification related

--- a/notifier/slack/notify_test.go
+++ b/notifier/slack/notify_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mercari/tfnotify/terraform"
 	"github.com/lestrrat-go/slack/objects"
+	"github.com/mercari/tfnotify/terraform"
 )
 
 func TestNotify(t *testing.T) {


### PR DESCRIPTION
## WHAT

Title

## WHY

Right now, the apply result is commented on the commit just before the merge commit in master. If the PR merged in is not up to date with master, someone else's commit may be the commit right before the merge commit. This makes the apply result get commented on a completely unrelated commit instead of in the PR.
