### PR TITLE
Add support to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Currently, supported CI are here:
 - Drone
 - Jenkins
 - GitLab CI
+- GitHub Actions
 
 ### Private Repository Considerations
 GitHub private repositories require the `repo` and `write:discussion` permissions.

--- a/ci.go
+++ b/ci.go
@@ -136,3 +136,13 @@ func gitlabci() (ci CI, err error) {
 	ci.PR.Number, err = strconv.Atoi(pr)
 	return ci, err
 }
+
+func githubActions() (ci CI, err error) {
+	ci.URL = fmt.Sprintf(
+		"https://github.com/%s/runs/%s",
+		os.Getenv("GITHUB_REPOSITORY"),
+		os.Getenv("GITHUB_RUN_ID"),
+	)
+	ci.PR.Revision = os.Getenv("GITHUB_SHA")
+	return ci, err
+}

--- a/config/config.go
+++ b/config/config.go
@@ -125,6 +125,8 @@ func (cfg *Config) Validation() error {
 		// ok pattern
 	case "jenkins":
 		// ok pattern
+	case "github-actions":
+		// ok pattern
 	default:
 		return fmt.Errorf("%s: not supported yet", cfg.CI)
 	}

--- a/main.go
+++ b/main.go
@@ -77,6 +77,11 @@ func (t *tfnotify) Run() error {
 		if err != nil {
 			return err
 		}
+	case "github-actions":
+		ci, err = githubActions()
+		if err != nil {
+			return err
+		}
 	case "":
 		return fmt.Errorf("CI service: required (e.g. circleci)")
 	default:


### PR DESCRIPTION
## WHAT

Add support to GitHub Actions as CI service.

## WHY

GitHub Actions creates GITHUB_TOKEN for a repository automatically. So, we don't have to create any GitHub accounts for tfnotify.