### PR TITLE
Fix github actions link

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -139,7 +139,7 @@ func gitlabci() (ci CI, err error) {
 
 func githubActions() (ci CI, err error) {
 	ci.URL = fmt.Sprintf(
-		"https://github.com/%s/runs/%s",
+		"https://github.com/%s/actions/runs/%s",
 		os.Getenv("GITHUB_REPOSITORY"),
 		os.Getenv("GITHUB_RUN_ID"),
 	)


### PR DESCRIPTION
## WHAT

Modify the CI link URL of Github action.

## WHY

The link when using the environment variable GITHUB_RUN_ID is wrong.