### PR TITLE
Set PR number also on gh actions

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -144,5 +144,23 @@ func githubActions() (ci CI, err error) {
 		os.Getenv("GITHUB_RUN_ID"),
 	)
 	ci.PR.Revision = os.Getenv("GITHUB_SHA")
+	pr := ""
+	if prNumber, ok := os.LookupEnv("PR_NUMBER"); !ok && prNumber != "" {
+		pr = prNumber
+	} else {
+		ref := os.Getenv("GITHUB_REF")
+
+		if ref != "" {
+			prRegex := regexp.MustCompile(`refs/pull/\d*/merge`)
+			if prRegex.MatchString(ref) {
+				strLen := strings.Split(ref, "/")
+				pr = strLen[2]
+			}
+		}
+	}
+	if pr == "" {
+		return ci, nil
+	}
+	ci.PR.Number, err = strconv.Atoi(pr)
 	return ci, err
 }

--- a/ci_test.go
+++ b/ci_test.go
@@ -736,11 +736,28 @@ func TestGitHubActions(t *testing.T) {
 				os.Setenv("GITHUB_SHA", "abcdefg")
 				os.Setenv("GITHUB_REPOSITORY", "mercari/tfnotify")
 				os.Setenv("GITHUB_RUN_ID", "12345")
+				os.Setenv("GITHUB_REF", "refs/pull/123/merge")
 			},
 			ci: CI{
 				PR: PullRequest{
 					Revision: "abcdefg",
-					Number:   0,
+					Number:   123,
+				},
+				URL: "https://github.com/mercari/tfnotify/actions/runs/12345",
+			},
+			ok: true,
+		},
+		{
+			fn: func() {
+				os.Setenv("GITHUB_SHA", "abcdefg")
+				os.Setenv("GITHUB_REPOSITORY", "mercari/tfnotify")
+				os.Setenv("GITHUB_RUN_ID", "12345")
+				os.Setenv("PR_NUMBER", "123")
+			},
+			ci: CI{
+				PR: PullRequest{
+					Revision: "abcdefg",
+					Number:   123,
 				},
 				URL: "https://github.com/mercari/tfnotify/actions/runs/12345",
 			},


### PR DESCRIPTION
## WHAT

Set PR number also for GitHub action based on  GITHUB_REF. 
Allow to override it and set PR_NUMBER manually for cases where GITHUB_REF is not enough.
## WHY

Today when running tfnotify in github action, the github notifier is not supported - because the PR number is not set. This PR allows users to fix it. Tested locally - working as expected.
