### PR TITLE
fix typo on readme and godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ go get -u github.com/mercari/tfnotify
 2. Bind parsed results to Go templates
 3. Notify it to any platform (e.g. GitHub) as you like
 
-Detailed specifications such as templates and notification destinations can be customized from the configration files (described later).
+Detailed specifications such as templates and notification destinations can be customized from the configuration files (described later).
 
 ## Usage
 

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -219,7 +219,7 @@ func generateOutput(kind, template string, data map[string]interface{}, useRawOu
 	return b.String(), nil
 }
 
-// Execute binds the execution result of terraform command into tepmlate
+// Execute binds the execution result of terraform command into template
 func (t *DefaultTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
@@ -237,7 +237,7 @@ func (t *DefaultTemplate) Execute() (string, error) {
 	return resp, nil
 }
 
-// Execute binds the execution result of terraform fmt into tepmlate
+// Execute binds the execution result of terraform fmt into template
 func (t *FmtTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
@@ -255,7 +255,7 @@ func (t *FmtTemplate) Execute() (string, error) {
 	return resp, nil
 }
 
-// Execute binds the execution result of terraform plan into tepmlate
+// Execute binds the execution result of terraform plan into template
 func (t *PlanTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
@@ -291,7 +291,7 @@ func (t *DestroyWarningTemplate) Execute() (string, error) {
 	return resp, nil
 }
 
-// Execute binds the execution result of terraform apply into tepmlate
+// Execute binds the execution result of terraform apply into template
 func (t *ApplyTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,


### PR DESCRIPTION
## WHAT

Fix typo on README and GoDoc

## WHY

Make the wording better
