### PR TITLE
Support Google Cloud Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Currently, supported CI are here:
 - Jenkins
 - GitLab CI
 - GitHub Actions
+- Google Cloud Build
 
 ### Private Repository Considerations
 GitHub private repositories require the `repo` and `write:discussion` permissions.
@@ -389,6 +390,17 @@ GitHub private repositories require the `repo` and `write:discussion` permission
   - [Git Plugin](https://wiki.jenkins.io/display/JENKINS/Git+Plugin)
 - Environment Variable
   - `PULL_REQUEST_NUMBER` or `PULL_REQUEST_URL` are required to set by user for Pull Request Usage
+
+### Google Cloud Build Considerations
+
+- These environment variables are needed to be set using [substitutions](https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values)
+  - `COMMIT_SHA`
+  - `BUILD_ID`
+  - `PROJECT_ID`
+  - `_PR_NUMBER`
+- Recommended trigger events
+  - `terraform plan`: Pull request
+  - `terraform apply`: Push to branch
 
 ## Committers
 

--- a/ci.go
+++ b/ci.go
@@ -146,3 +146,19 @@ func githubActions() (ci CI, err error) {
 	ci.PR.Revision = os.Getenv("GITHUB_SHA")
 	return ci, err
 }
+
+func cloudbuild() (ci CI, err error) {
+	ci.PR.Number = 0
+	ci.PR.Revision = os.Getenv("COMMIT_SHA")
+	ci.URL = fmt.Sprintf(
+		"https://console.cloud.google.com/cloud-build/builds/%s?project=%s",
+		os.Getenv("BUILD_ID"),
+		os.Getenv("PROJECT_ID"),
+	)
+	pr := os.Getenv("_PR_NUMBER")
+	if pr == "" {
+		return ci, nil
+	}
+	ci.PR.Number, err = strconv.Atoi(pr)
+	return ci, err
+}

--- a/ci_test.go
+++ b/ci_test.go
@@ -759,3 +759,89 @@ func TestGitHubActions(t *testing.T) {
 		}
 	}
 }
+
+func TestCloudBuild(t *testing.T) {
+	envs := []string{
+		"COMMIT_SHA",
+		"BUILD_ID",
+		"PROJECT_ID",
+		"_PR_NUMBER",
+	}
+	saveEnvs := make(map[string]string)
+	for _, key := range envs {
+		saveEnvs[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+	defer func() {
+		for key, value := range saveEnvs {
+			os.Setenv(key, value)
+		}
+	}()
+
+	// https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values
+	testCases := []struct {
+		fn func()
+		ci CI
+		ok bool
+	}{
+		{
+			fn: func() {
+				os.Setenv("COMMIT_SHA", "abcdefg")
+				os.Setenv("BUILD_ID", "build-id")
+				os.Setenv("PROJECT_ID", "gcp-project-id")
+				os.Setenv("_PR_NUMBER", "123")
+			},
+			ci: CI{
+				PR: PullRequest{
+					Revision: "abcdefg",
+					Number:   123,
+				},
+				URL: "https://console.cloud.google.com/cloud-build/builds/build-id?project=gcp-project-id",
+			},
+			ok: true,
+		},
+		{
+			fn: func() {
+				os.Setenv("COMMIT_SHA", "")
+				os.Setenv("BUILD_ID", "build-id")
+				os.Setenv("PROJECT_ID", "gcp-project-id")
+				os.Setenv("_PR_NUMBER", "")
+			},
+			ci: CI{
+				PR: PullRequest{
+					Revision: "",
+					Number:   0,
+				},
+				URL: "https://console.cloud.google.com/cloud-build/builds/build-id?project=gcp-project-id",
+			},
+			ok: true,
+		},
+		{
+			fn: func() {
+				os.Setenv("COMMIT_SHA", "")
+				os.Setenv("BUILD_ID", "build-id")
+				os.Setenv("PROJECT_ID", "gcp-project-id")
+				os.Setenv("_PR_NUMBER", "abc")
+			},
+			ci: CI{
+				PR: PullRequest{
+					Revision: "",
+					Number:   0,
+				},
+				URL: "https://console.cloud.google.com/cloud-build/builds/build-id?project=gcp-project-id",
+			},
+			ok: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase.fn()
+		ci, err := cloudbuild()
+		if !reflect.DeepEqual(ci, testCase.ci) {
+			t.Errorf("got %q but want %q", ci, testCase.ci)
+		}
+		if (err == nil) != testCase.ok {
+			t.Errorf("got error %q", err)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -146,6 +146,8 @@ func (cfg *Config) Validation() error {
 		// ok pattern
 	case "github-actions":
 		// ok pattern
+	case "cloud-build", "cloudbuild":
+		// ok pattern
 	default:
 		return fmt.Errorf("%s: not supported yet", cfg.CI)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -221,6 +221,14 @@ func TestValidation(t *testing.T) {
 			expected: "notifier is missing",
 		},
 		{
+			contents: []byte("ci: cloudbuild\n"),
+			expected: "notifier is missing",
+		},
+		{
+			contents: []byte("ci: cloud-build\n"),
+			expected: "notifier is missing",
+		},
+		{
 			contents: []byte("ci: circleci\nnotifier:\n  github:\n"),
 			expected: "notifier is missing",
 		},

--- a/main.go
+++ b/main.go
@@ -82,6 +82,11 @@ func (t *tfnotify) Run() error {
 		if err != nil {
 			return err
 		}
+	case "cloud-build", "cloudbuild":
+		ci, err = cloudbuild()
+		if err != nil {
+			return err
+		}
 	case "":
 		return fmt.Errorf("CI service: required (e.g. circleci)")
 	default:


### PR DESCRIPTION
## WHAT

Add Google Cloud Build as a supported CI

## WHY

When running `terraform` to operate GCP resources, using Google Cloud Build is a secure way because it doesn't need to create a Service Account key file.

---

I'm already using it in my personal project and it's working fine:
![image](https://user-images.githubusercontent.com/241542/88473711-3ff1b480-cf5b-11ea-9e17-16f1975c57d0.png)
