### PR TITLE
Use Go 1.14 for release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: '1.14.x'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
## WHAT

Use Go 1.14 to build binaries for release, as well as testing.

## WHY

We use Go 1.14 to run tests ([ref](https://github.com/mercari/tfnotify/blob/57494ec80c926a12967c8634226ef60e834b3dfd/.github/workflows/test.yml#L19)). However, GoReleaser still uses Go 1.13.

We should use the same Go version through the development/release pipeline.