### PR TITLE
Fix error when there is only 1 commit

### DIFF
--- a/notifier/github/commits.go
+++ b/notifier/github/commits.go
@@ -37,8 +37,8 @@ func (g *CommitsService) lastOne(commits []string, revision string) (string, err
 	if revision == "" {
 		return "", errors.New("no revision specified")
 	}
-	if len(commits) == 0 {
-		return "", errors.New("no commits")
+	if len(commits) < 2 {
+		return "", errors.New("not enough commits")
 	}
 	// e.g.
 	// a0ce5bf 2018/04/05 20:50:01 (HEAD -> master, origin/master)

--- a/notifier/github/commits_test.go
+++ b/notifier/github/commits_test.go
@@ -70,6 +70,15 @@ func TestCommitsLastOne(t *testing.T) {
 			lastRev:  "",
 			ok:       false,
 		},
+		{
+			// one commit
+			commits: []string{
+				"04e0917e448b662c2b16330fad50e97af16ff27a",
+			},
+			revision: "04e0917e448b662c2b16330fad50e97af16ff27a",
+			lastRev:  "",
+			ok:       false,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/notifier/gitlab/commits.go
+++ b/notifier/gitlab/commits.go
@@ -33,8 +33,8 @@ func (g *CommitsService) lastOne(commits []string, revision string) (string, err
 	if revision == "" {
 		return "", errors.New("no revision specified")
 	}
-	if len(commits) == 0 {
-		return "", errors.New("no commits")
+	if len(commits) < 2 {
+		return "", errors.New("not enough commits")
 	}
 
 	return commits[1], nil

--- a/notifier/gitlab/commits_test.go
+++ b/notifier/gitlab/commits_test.go
@@ -70,6 +70,15 @@ func TestCommitsLastOne(t *testing.T) {
 			lastRev:  "",
 			ok:       false,
 		},
+		{
+			// one commit
+			commits: []string{
+				"04e0917e448b662c2b16330fad50e97af16ff27a",
+			},
+			revision: "04e0917e448b662c2b16330fad50e97af16ff27a",
+			lastRev:  "",
+			ok:       false,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## WHAT

Fix by 1 error in extracting previous commit

## WHY

When the repository contains only 1 commit, the extraction of the previous commit fails:
```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/mercari/tfnotify/notifier/github.(*CommitsService).lastOne(...)
	/home/runner/work/tfnotify/tfnotify/notifier/github/commits.go:48
github.com/mercari/tfnotify/notifier/github.(*NotifyService).Notify(0xc000102ad0, 0xc00018e480, 0x441, 0xc00000e018, 0xc000190000, 0x32e)
	/home/runner/work/tfnotify/tfnotify/notifier/github/notify.go:94 +0x875
main.(*tfnotify).Run(0xc000147380, 0xc000172d90, 0x8)
	/home/runner/work/tfnotify/tfnotify/main.go:188 +0x5e2
main.cmdApply(0xc000102840, 0x0, 0xc0000109a0)
	/home/runner/work/tfnotify/tfnotify/main.go:320 +0x1e8
```