### PR TITLE
Change main.version from const to var

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,9 @@ import (
 const (
 	name        = "tfnotify"
 	description = "Notify the execution result of terraform command"
+)
 
+var (
 	version = "unset"
 )
 


### PR DESCRIPTION
## WHAT

Change main.version from const to var.
If applied, this commit will fix #83 

Here's the Github release that includes this commit.
https://github.com/kei2100/tfnotify/releases/tag/v0.7.1-beta.1

```bash
$ wget https://github.com/kei2100/tfnotify/releases/download/v0.7.1-beta.1/tfnotify_darwin_amd64.tar.gz

$ tar xfv tfnotify_darwin_amd64.tar.gz

$ ./tfnotify --version
tfnotify version 0.7.1-beta.1
```