### PR TITLE
refactor: add context.Context to first argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -33,7 +34,7 @@ type tfnotify struct {
 }
 
 // Run sends the notification with notifier
-func (t *tfnotify) Run() error {
+func (t *tfnotify) Run(ctx context.Context) error {
 	ciname := t.config.CI
 	if t.context.GlobalString("ci") != "" {
 		ciname = t.context.GlobalString("ci")
@@ -190,7 +191,7 @@ func (t *tfnotify) Run() error {
 		return fmt.Errorf("no notifier specified at all")
 	}
 
-	return NewExitError(notifier.Notify(tee(os.Stdin, os.Stdout)))
+	return NewExitError(notifier.Notify(ctx, tee(os.Stdin, os.Stdout)))
 }
 
 func main() {
@@ -288,7 +289,7 @@ func cmdFmt(ctx *cli.Context) error {
 		parser:   terraform.NewFmtParser(),
 		template: terraform.NewFmtTemplate(cfg.Terraform.Fmt.Template),
 	}
-	return t.Run()
+	return t.Run(context.Background())
 }
 
 func cmdPlan(ctx *cli.Context) error {
@@ -308,7 +309,7 @@ func cmdPlan(ctx *cli.Context) error {
 		destroyWarningTemplate: terraform.NewDestroyWarningTemplate(cfg.Terraform.Plan.WhenDestroy.Template),
 		warnDestroy:            warnDestroy,
 	}
-	return t.Run()
+	return t.Run(context.Background())
 }
 
 func cmdApply(ctx *cli.Context) error {
@@ -322,5 +323,5 @@ func cmdApply(ctx *cli.Context) error {
 		parser:   terraform.NewApplyParser(),
 		template: terraform.NewApplyTemplate(cfg.Terraform.Apply.Template),
 	}
-	return t.Run()
+	return t.Run(context.Background())
 }

--- a/notifier/github/comment_test.go
+++ b/notifier/github/comment_test.go
@@ -60,7 +60,7 @@ func TestCommentPost(t *testing.T) {
 		}
 		api := newFakeAPI()
 		client.API = &api
-		err = client.Comment.Post(testCase.body, testCase.opt)
+		err = client.Comment.Post(context.Background(), testCase.body, testCase.opt)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}
@@ -111,7 +111,7 @@ func TestCommentList(t *testing.T) {
 		}
 		api := newFakeAPI()
 		client.API = &api
-		comments, err := client.Comment.List(testCase.number)
+		comments, err := client.Comment.List(context.Background(), testCase.number)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}
@@ -151,7 +151,7 @@ func TestCommentDelete(t *testing.T) {
 		}
 		api := newFakeAPI()
 		client.API = &api
-		err = client.Comment.Delete(testCase.id)
+		err = client.Comment.Delete(context.Background(), testCase.id)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}
@@ -227,7 +227,7 @@ func TestCommentGetDuplicates(t *testing.T) {
 			t.Fatal(err)
 		}
 		client.API = &api
-		comments := client.Comment.getDuplicates(testCase.title)
+		comments := client.Comment.getDuplicates(context.Background(), testCase.title)
 		if !reflect.DeepEqual(comments, testCase.comments) {
 			t.Errorf("got %q but want %q", comments, testCase.comments)
 		}

--- a/notifier/github/notify_test.go
+++ b/notifier/github/notify_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mercari/tfnotify/terraform"
@@ -215,7 +216,7 @@ func TestNotifyNotify(t *testing.T) {
 		}
 		api := newFakeAPI()
 		client.API = &api
-		exitCode, err := client.Notify.Notify(testCase.body)
+		exitCode, err := client.Notify.Notify(context.Background(), testCase.body)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}

--- a/notifier/gitlab/notify.go
+++ b/notifier/gitlab/notify.go
@@ -1,6 +1,8 @@
 package gitlab
 
 import (
+	"context"
+
 	"github.com/mercari/tfnotify/terraform"
 )
 
@@ -9,7 +11,7 @@ import (
 type NotifyService service
 
 // Notify posts comment optimized for notifications
-func (g *NotifyService) Notify(body string) (exit int, err error) {
+func (g *NotifyService) Notify(ctx context.Context, body string) (exit int, err error) {
 	cfg := g.client.Config
 	parser := g.client.Config.Parser
 	template := g.client.Config.Template

--- a/notifier/gitlab/notify_test.go
+++ b/notifier/gitlab/notify_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mercari/tfnotify/terraform"
@@ -130,7 +131,7 @@ func TestNotifyNotify(t *testing.T) {
 		}
 		api := newFakeAPI()
 		client.API = &api
-		exitCode, err := client.Notify.Notify(testCase.body)
+		exitCode, err := client.Notify.Notify(context.Background(), testCase.body)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,6 +1,8 @@
 package notifier
 
+import "context"
+
 // Notifier is a notification interface
 type Notifier interface {
-	Notify(body string) (exit int, err error)
+	Notify(ctx context.Context, body string) (exit int, err error)
 }

--- a/notifier/slack/notify.go
+++ b/notifier/slack/notify.go
@@ -13,7 +13,7 @@ import (
 type NotifyService service
 
 // Notify posts comment optimized for notifications
-func (s *NotifyService) Notify(body string) (exit int, err error) {
+func (s *NotifyService) Notify(ctx context.Context, body string) (exit int, err error) {
 	cfg := s.client.Config
 	parser := s.client.Config.Parser
 	template := s.client.Config.Template
@@ -60,6 +60,6 @@ func (s *NotifyService) Notify(body string) (exit int, err error) {
 
 	attachments.Append(attachment)
 	// _, err = s.client.Chat().PostMessage(cfg.Channel).Username(cfg.Botname).SetAttachments(attachments).Do(cfg.Context)
-	_, err = s.client.API.ChatPostMessage(context.Background(), attachments)
+	_, err = s.client.API.ChatPostMessage(ctx, attachments)
 	return result.ExitCode, err
 }

--- a/notifier/slack/notify_test.go
+++ b/notifier/slack/notify_test.go
@@ -54,7 +54,7 @@ func TestNotify(t *testing.T) {
 			t.Fatal(err)
 		}
 		client.API = &fake
-		exitCode, err := client.Notify.Notify(testCase.body)
+		exitCode, err := client.Notify.Notify(context.Background(), testCase.body)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}

--- a/notifier/typetalk/notify.go
+++ b/notifier/typetalk/notify.go
@@ -11,7 +11,7 @@ import (
 type NotifyService service
 
 // Notify posts message to Typetalk.
-func (s *NotifyService) Notify(body string) (exit int, err error) {
+func (s *NotifyService) Notify(ctx context.Context, body string) (exit int, err error) {
 	cfg := s.client.Config
 	parser := s.client.Config.Parser
 	template := s.client.Config.Template
@@ -39,6 +39,6 @@ func (s *NotifyService) Notify(body string) (exit int, err error) {
 		return result.ExitCode, err
 	}
 
-	_, _, err = s.client.API.ChatPostMessage(context.Background(), text)
+	_, _, err = s.client.API.ChatPostMessage(ctx, text)
 	return result.ExitCode, err
 }

--- a/notifier/typetalk/notify_test.go
+++ b/notifier/typetalk/notify_test.go
@@ -53,7 +53,7 @@ func TestNotify(t *testing.T) {
 			t.Fatal(err)
 		}
 		client.API = &fake
-		exitCode, err := client.Notify.Notify(testCase.body)
+		exitCode, err := client.Notify.Notify(context.Background(), testCase.body)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}


### PR DESCRIPTION
## WHAT

Add context.Context to first argument

## WHY

To cancel functions properly.