### PR TITLE
style: format code with gofumpt

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -427,7 +427,7 @@ func createDummy(file string) {
 	if _, err := os.Stat(file); err == nil {
 		return
 	}
-	f, err := os.OpenFile(file, os.O_RDONLY|os.O_CREATE, 0666)
+	f, err := os.OpenFile(file, os.O_RDONLY|os.O_CREATE, 0o666)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mercari/tfnotify
 
-go 1.12
+go 1.13
 
 require (
 	github.com/google/go-github v17.0.0+incompatible

--- a/notifier/github/comment_test.go
+++ b/notifier/github/comment_test.go
@@ -69,11 +69,11 @@ func TestCommentPost(t *testing.T) {
 
 func TestCommentList(t *testing.T) {
 	comments := []*github.IssueComment{
-		&github.IssueComment{
+		{
 			ID:   github.Int64(371748792),
 			Body: github.String("comment 1"),
 		},
-		&github.IssueComment{
+		{
 			ID:   github.Int64(371765743),
 			Body: github.String("comment 2"),
 		},
@@ -163,19 +163,19 @@ func TestCommentGetDuplicates(t *testing.T) {
 	api.FakeIssuesListComments = func(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error) {
 		var comments []*github.IssueComment
 		comments = []*github.IssueComment{
-			&github.IssueComment{
+			{
 				ID:   github.Int64(371748792),
 				Body: github.String("## Plan result\nfoo message\n"),
 			},
-			&github.IssueComment{
+			{
 				ID:   github.Int64(371765743),
 				Body: github.String("## Plan result\nbar message\n"),
 			},
-			&github.IssueComment{
+			{
 				ID:   github.Int64(371765744),
 				Body: github.String("## Plan result\nbaz message\n"),
 			},
-			&github.IssueComment{
+			{
 				ID:   github.Int64(371765745),
 				Body: github.String("## Plan result <build URL>\nbaz message\n"),
 			},
@@ -192,7 +192,7 @@ func TestCommentGetDuplicates(t *testing.T) {
 			title:   "## Plan result",
 			message: "foo message",
 			comments: []*github.IssueComment{
-				&github.IssueComment{
+				{
 					ID:   github.Int64(371748792),
 					Body: github.String("## Plan result\nfoo message\n"),
 				},
@@ -207,11 +207,11 @@ func TestCommentGetDuplicates(t *testing.T) {
 			title:   "## Plan result",
 			message: "baz message",
 			comments: []*github.IssueComment{
-				&github.IssueComment{
+				{
 					ID:   github.Int64(371765744),
 					Body: github.String("## Plan result\nbaz message\n"),
 				},
-				&github.IssueComment{
+				{
 					ID:   github.Int64(371765745),
 					Body: github.String("## Plan result <build URL>\nbaz message\n"),
 				},

--- a/notifier/github/github_test.go
+++ b/notifier/github/github_test.go
@@ -70,11 +70,11 @@ func newFakeAPI() fakeAPI {
 		FakeIssuesListComments: func(ctx context.Context, number int, opt *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error) {
 			var comments []*github.IssueComment
 			comments = []*github.IssueComment{
-				&github.IssueComment{
+				{
 					ID:   github.Int64(371748792),
 					Body: github.String("comment 1"),
 				},
-				&github.IssueComment{
+				{
 					ID:   github.Int64(371765743),
 					Body: github.String("comment 2"),
 				},
@@ -83,11 +83,11 @@ func newFakeAPI() fakeAPI {
 		},
 		FakeIssuesListLabels: func(ctx context.Context, number int, opts *github.ListOptions) ([]*github.Label, *github.Response, error) {
 			labels := []*github.Label{
-				&github.Label{
+				{
 					ID:   github.Int64(371748792),
 					Name: github.String("label 1"),
 				},
-				&github.Label{
+				{
 					ID:   github.Int64(371765743),
 					Name: github.String("label 2"),
 				},
@@ -110,13 +110,13 @@ func newFakeAPI() fakeAPI {
 		FakeRepositoriesListCommits: func(ctx context.Context, opt *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
 			var commits []*github.RepositoryCommit
 			commits = []*github.RepositoryCommit{
-				&github.RepositoryCommit{
+				{
 					SHA: github.String("04e0917e448b662c2b16330fad50e97af16ff27a"),
 				},
-				&github.RepositoryCommit{
+				{
 					SHA: github.String("04e0917e448b662c2b16330fad50e97af16ff27b"),
 				},
-				&github.RepositoryCommit{
+				{
 					SHA: github.String("04e0917e448b662c2b16330fad50e97af16ff27c"),
 				},
 			}

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -2,8 +2,9 @@ package github
 
 import (
 	"context"
-	"github.com/mercari/tfnotify/terraform"
 	"net/http"
+
+	"github.com/mercari/tfnotify/terraform"
 )
 
 // NotifyService handles communication with the notification related

--- a/notifier/gitlab/comment_test.go
+++ b/notifier/gitlab/comment_test.go
@@ -68,11 +68,11 @@ func TestCommentPost(t *testing.T) {
 
 func TestCommentList(t *testing.T) {
 	comments := []*gitlab.Note{
-		&gitlab.Note{
+		{
 			ID:   371748792,
 			Body: "comment 1",
 		},
-		&gitlab.Note{
+		{
 			ID:   371765743,
 			Body: "comment 2",
 		},

--- a/notifier/gitlab/gitlab_test.go
+++ b/notifier/gitlab/gitlab_test.go
@@ -48,11 +48,11 @@ func newFakeAPI() fakeAPI {
 		FakeListMergeRequestNotes: func(mergeRequest int, opt *gitlab.ListMergeRequestNotesOptions, options ...gitlab.OptionFunc) ([]*gitlab.Note, *gitlab.Response, error) {
 			var comments []*gitlab.Note
 			comments = []*gitlab.Note{
-				&gitlab.Note{
+				{
 					ID:   371748792,
 					Body: "comment 1",
 				},
-				&gitlab.Note{
+				{
 					ID:   371765743,
 					Body: "comment 2",
 				},
@@ -67,13 +67,13 @@ func newFakeAPI() fakeAPI {
 		FakeListCommits: func(opt *gitlab.ListCommitsOptions, options ...gitlab.OptionFunc) ([]*gitlab.Commit, *gitlab.Response, error) {
 			var commits []*gitlab.Commit
 			commits = []*gitlab.Commit{
-				&gitlab.Commit{
+				{
 					ID: "04e0917e448b662c2b16330fad50e97af16ff27a",
 				},
-				&gitlab.Commit{
+				{
 					ID: "04e0917e448b662c2b16330fad50e97af16ff27b",
 				},
-				&gitlab.Commit{
+				{
 					ID: "04e0917e448b662c2b16330fad50e97af16ff27c",
 				},
 			}


### PR DESCRIPTION
## WHAT

Format code with gofumpt

https://github.com/mvdan/gofumpt

```
$ git ls-files | grep -E "^.*\.go$" | xargs gofumpt -l -s -w
config/config_test.go
notifier/github/comment_test.go
notifier/github/github_test.go
notifier/github/notify.go
notifier/gitlab/comment_test.go
notifier/gitlab/gitlab_test.go
```

## WHY

Clean code.
