### PR TITLE
Add support for GitHub Actions on GitHub Enterprise

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -139,7 +139,8 @@ func gitlabci() (ci CI, err error) {
 
 func githubActions() (ci CI, err error) {
 	ci.URL = fmt.Sprintf(
-		"https://github.com/%s/actions/runs/%s",
+		"%s/%s/actions/runs/%s",
+		os.Getenv("GITHUB_SERVER_URL"),
 		os.Getenv("GITHUB_REPOSITORY"),
 		os.Getenv("GITHUB_RUN_ID"),
 	)

--- a/ci_test.go
+++ b/ci_test.go
@@ -711,6 +711,7 @@ func TestGitLabCI(t *testing.T) {
 func TestGitHubActions(t *testing.T) {
 	envs := []string{
 		"GITHUB_SHA",
+		"GITHUB_SERVER_URL",
 		"GITHUB_REPOSITORY",
 		"GITHUB_RUN_ID",
 	}
@@ -734,6 +735,7 @@ func TestGitHubActions(t *testing.T) {
 		{
 			fn: func() {
 				os.Setenv("GITHUB_SHA", "abcdefg")
+				os.Setenv("GITHUB_SERVER_URL", "https://github.com")
 				os.Setenv("GITHUB_REPOSITORY", "mercari/tfnotify")
 				os.Setenv("GITHUB_RUN_ID", "12345")
 			},


### PR DESCRIPTION
## WHAT

Modify to use the environment variable to the URL of GitHub Actions.

## WHY

This is because `CI link` is incorrect when using GitHub Actions on GitHub Enterprise.

Please take a look at ["Note" in this document](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) as well.
