### PR TITLE
Enable tfnotify executed by GitHub Actions to add pull request comments

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -18,6 +20,20 @@ type CI struct {
 type PullRequest struct {
 	Revision string
 	Number   int
+}
+
+type gitHubActionsEventIssue struct {
+	Number int `json:"number"`
+}
+
+type gitHubActionsEventPullRequest struct {
+	Number int `json:"number"`
+}
+
+type gitHubActionsEventPayload struct {
+	Issue       *gitHubActionsEventIssue       `json:"issue"`
+	PullRequest *gitHubActionsEventPullRequest `json:"pull_request"`
+	Number      int                            `json:"number"`
 }
 
 func circleci() (ci CI, err error) {
@@ -144,6 +160,30 @@ func githubActions() (ci CI, err error) {
 		os.Getenv("GITHUB_RUN_ID"),
 	)
 	ci.PR.Revision = os.Getenv("GITHUB_SHA")
+
+	// Extract the pull request number from the event payload that triggered the current workflow.
+	// See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+	ci.PR.Number = 0
+	eventPath := os.Getenv("GITHUB_EVENT_PATH")
+	if eventPath != "" {
+		bytes, err := ioutil.ReadFile(eventPath)
+		if err != nil {
+			return ci, err
+		}
+
+		eventPayload := gitHubActionsEventPayload{}
+		if err := json.Unmarshal(bytes, &eventPayload); err != nil {
+			return ci, err
+		}
+
+		if eventPayload.Issue != nil {
+			ci.PR.Number = eventPayload.Issue.Number
+		} else if eventPayload.PullRequest != nil {
+			ci.PR.Number = eventPayload.PullRequest.Number
+		} else {
+			ci.PR.Number = eventPayload.Number
+		}
+	}
 	return ci, err
 }
 


### PR DESCRIPTION
## WHAT

This PR allows tfnotify executed by GitHub Actions on pull requests to add pull request comments instead of commit comments.

For GitHub Actions, the content of the event that triggered the action is stored as a JSON file at `GITHUB_EVENT_PATH`.
For the `pull_request` events, we can read the number of the pull request from the file.

For more details about `GITHUB_EVENT_PATH` and the content of the event payload, please refer to these guides.

* https://docs.github.com/actions/reference/environment-variables#default-environment-variables
* https://docs.github.com/en/actions/reference/events-that-trigger-workflows

As an example of implementation, an official helper for GitHub Actions reads a pull request number or an issue number from the file.

* https://github.com/actions/toolkit/blob/a31b7eca9ee2ad5ee5555964ec94ff394245fdad/packages/github/src/context.ts#L30-L39

## WHY

This change allows users of tfnotify and GitHub Actons to comment results of plan or apply command to pull requests.