### PR TITLE
Add CI url as Link template value for slack notification

### DIFF
--- a/notifier/slack/notify.go
+++ b/notifier/slack/notify.go
@@ -43,6 +43,7 @@ func (s *NotifyService) Notify(body string) (exit int, err error) {
 		Message: cfg.Message,
 		Result:  result.Result,
 		Body:    body,
+		Link:    cfg.CI,
 	})
 	text, err := template.Execute()
 	if err != nil {


### PR DESCRIPTION
## WHAT

Link template variable can be used for notifications to Slack.

## WHY

I would like to jump to CI from a notified Slack message.
