### PR TITLE
Support regional (=private pool) Cloud Build

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+const (
+	defaultCloudBuildRegion = "global"
+)
+
 // CI represents a common information obtained from all CI platforms
 type CI struct {
 	PR  PullRequest
@@ -153,7 +157,7 @@ func cloudbuild() (ci CI, err error) {
 
 	region := os.Getenv("REGION")
 	if region == "" {
-		region = "global"
+		region = defaultCloudBuildRegion
 	}
 
 	ci.URL = fmt.Sprintf(

--- a/ci.go
+++ b/ci.go
@@ -150,8 +150,15 @@ func githubActions() (ci CI, err error) {
 func cloudbuild() (ci CI, err error) {
 	ci.PR.Number = 0
 	ci.PR.Revision = os.Getenv("COMMIT_SHA")
+
+	region := os.Getenv("REGION")
+	if region == "" {
+		region = "global"
+	}
+
 	ci.URL = fmt.Sprintf(
-		"https://console.cloud.google.com/cloud-build/builds/%s?project=%s",
+		"https://console.cloud.google.com/cloud-build/builds;region=%s/%s?project=%s",
+		region,
 		os.Getenv("BUILD_ID"),
 		os.Getenv("PROJECT_ID"),
 	)

--- a/ci_test.go
+++ b/ci_test.go
@@ -766,6 +766,7 @@ func TestCloudBuild(t *testing.T) {
 		"BUILD_ID",
 		"PROJECT_ID",
 		"_PR_NUMBER",
+		"REGION",
 	}
 	saveEnvs := make(map[string]string)
 	for _, key := range envs {
@@ -790,13 +791,14 @@ func TestCloudBuild(t *testing.T) {
 				os.Setenv("BUILD_ID", "build-id")
 				os.Setenv("PROJECT_ID", "gcp-project-id")
 				os.Setenv("_PR_NUMBER", "123")
+				os.Setenv("REGION", "asia-northeast1")
 			},
 			ci: CI{
 				PR: PullRequest{
 					Revision: "abcdefg",
 					Number:   123,
 				},
-				URL: "https://console.cloud.google.com/cloud-build/builds/build-id?project=gcp-project-id",
+				URL: "https://console.cloud.google.com/cloud-build/builds;region=asia-northeast1/build-id?project=gcp-project-id",
 			},
 			ok: true,
 		},
@@ -806,13 +808,14 @@ func TestCloudBuild(t *testing.T) {
 				os.Setenv("BUILD_ID", "build-id")
 				os.Setenv("PROJECT_ID", "gcp-project-id")
 				os.Setenv("_PR_NUMBER", "")
+				os.Setenv("REGION", "")
 			},
 			ci: CI{
 				PR: PullRequest{
 					Revision: "",
 					Number:   0,
 				},
-				URL: "https://console.cloud.google.com/cloud-build/builds/build-id?project=gcp-project-id",
+				URL: "https://console.cloud.google.com/cloud-build/builds;region=global/build-id?project=gcp-project-id",
 			},
 			ok: true,
 		},
@@ -828,7 +831,7 @@ func TestCloudBuild(t *testing.T) {
 					Revision: "",
 					Number:   0,
 				},
-				URL: "https://console.cloud.google.com/cloud-build/builds/build-id?project=gcp-project-id",
+				URL: "https://console.cloud.google.com/cloud-build/builds;region=global/build-id?project=gcp-project-id",
 			},
 			ok: false,
 		},


### PR DESCRIPTION
## WHAT

I have made changes to the link that will be used for `{{ .Link }}`.

## WHY

To support Cloud Build private pools( Ref: [https://cloud.google.com/build/docs/private-pools/private-pools-overview](https://console.cloud.google.com/cloud-build/builds;region=global/45826848-4bb9-426e-b2fa-b6fc1585bc58?project=kouzoh-ms-terraform-dev)).

The Cloud Build build IDs are generated by regions. Thus, if we want to jump to the detail page of the build that ran on private pool, we need to specify the region by `;region=<region>`.

The non-private-pool will be `global` region. Currently, there are no regions specified which will jump to the default `global` region, that's why it's working. For private pools, the current link that tfnotify posts, it will not lead us to the detail. The GCP will return 404 page 🙏 
