### PR TITLE
Fix region user defined substitution format

### DIFF
--- a/ci.go
+++ b/ci.go
@@ -155,7 +155,7 @@ func cloudbuild() (ci CI, err error) {
 	ci.PR.Number = 0
 	ci.PR.Revision = os.Getenv("COMMIT_SHA")
 
-	region := os.Getenv("REGION")
+	region := os.Getenv("_REGION")
 	if region == "" {
 		region = defaultCloudBuildRegion
 	}

--- a/ci_test.go
+++ b/ci_test.go
@@ -791,7 +791,7 @@ func TestCloudBuild(t *testing.T) {
 				os.Setenv("BUILD_ID", "build-id")
 				os.Setenv("PROJECT_ID", "gcp-project-id")
 				os.Setenv("_PR_NUMBER", "123")
-				os.Setenv("REGION", "asia-northeast1")
+				os.Setenv("_REGION", "asia-northeast1")
 			},
 			ci: CI{
 				PR: PullRequest{
@@ -808,7 +808,7 @@ func TestCloudBuild(t *testing.T) {
 				os.Setenv("BUILD_ID", "build-id")
 				os.Setenv("PROJECT_ID", "gcp-project-id")
 				os.Setenv("_PR_NUMBER", "")
-				os.Setenv("REGION", "")
+				os.Setenv("_REGION", "")
 			},
 			ci: CI{
 				PR: PullRequest{


### PR DESCRIPTION
## WHAT

I have added `_` (understore) before the variable.

## WHY

Because it doesn't follow the format. `REGION` is a custom substitution which the Cloud Build doesn't  build-in support.🙏 


> Substitutions must begin with an underscore (_) and use only uppercase-letters and numbers (respecting the regular expression _[A-Z0-9_]+)

Ref: https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
