### PR TITLE
Support Terraform `0.15` or later

### DIFF
--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -62,7 +62,7 @@ func NewFmtParser() *FmtParser {
 func NewPlanParser() *PlanParser {
 	return &PlanParser{
 		Pass: regexp.MustCompile(`(?m)^(Plan: \d|No changes.)`),
-		Fail: regexp.MustCompile(`(?m)^(Error: )`),
+		Fail: regexp.MustCompile(`(?m)^(\|\s{1})?(Error: )`),
 		// "0 to destroy" should be treated as "no destroy"
 		HasDestroy:   regexp.MustCompile(`(?m)([1-9][0-9]* to destroy.)`),
 		HasNoChanges: regexp.MustCompile(`(?m)^(No changes. Infrastructure is up-to-date.)`),
@@ -73,7 +73,7 @@ func NewPlanParser() *PlanParser {
 func NewApplyParser() *ApplyParser {
 	return &ApplyParser{
 		Pass: regexp.MustCompile(`(?m)^(Apply complete!)`),
-		Fail: regexp.MustCompile(`(?m)^(Error: )`),
+		Fail: regexp.MustCompile(`(?m)^(\|\s{1})?(Error: )`),
 	}
 }
 

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -472,7 +472,7 @@ func TestPlanParserParse(t *testing.T) {
 			},
 		},
 		{
-			name: "plan ng pattern",
+			name: "plan ng pattern 0.12",
 			body: planFailureResult0_12,
 			result: ParseResult{
 				Result: `Error: Error refreshing state: 4 error(s) occurred:
@@ -490,7 +490,7 @@ func TestPlanParserParse(t *testing.T) {
 			},
 		},
 		{
-			name: "plan ng pattern",
+			name: "plan ng pattern 0.15",
 			body: planFailureResult0_15,
 			result: ParseResult{
 				Result: `| Error: Error refreshing state: 4 error(s) occurred:
@@ -593,7 +593,7 @@ func TestApplyParserParse(t *testing.T) {
 			},
 		},
 		{
-			name: "apply ng pattern",
+			name: "apply ng pattern 0.12",
 			body: applyFailureResult0_12,
 			result: ParseResult{
 				Result: `Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for request "Enable Project Services tfnotify-jp-tfnotify-prod: map[logging.googleapis.com:{}]" returned error: failed to send enable services request: googleapi: Error 403: The caller does not have permission, forbidden
@@ -607,7 +607,7 @@ func TestApplyParserParse(t *testing.T) {
 			},
 		},
 		{
-			name: "apply ng pattern",
+			name: "apply ng pattern 0.15",
 			body: applyFailureResult0_15,
 			result: ParseResult{
 				Result: `| Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for request "Enable Project Services tfnotify-jp-tfnotify-prod: map[logging.googleapis.com:{}]" returned error: failed to send enable services request: googleapi: Error 403: The caller does not have permission, forbidden

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -368,7 +368,7 @@ google_dns_record_set.dev_tfnotifyapps_com: Refreshing state...
 
 
 | Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for request "Enable Project Services tfnotify-jp-tfnotify-prod: map[logging.googleapis.com:{}]" returned error: failed to send enable services request: googleapi: Error 403: The caller does not have permission, forbidden
-| 
+|
 |   on .terraform/modules/tfnotify-jp-tfnotify-prod/google_project_service.tf line 6, in resource "google_project_service" "gcp_api_service":
 |    6: resource "google_project_service" "gcp_api_service" {
 |
@@ -612,10 +612,10 @@ func TestApplyParserParse(t *testing.T) {
 			result: ParseResult{
 				Result: `| Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for request "Enable Project Services tfnotify-jp-tfnotify-prod: map[logging.googleapis.com:{}]" returned error: failed to send enable services request: googleapi: Error 403: The caller does not have permission, forbidden
 |
-| on .terraform/modules/tfnotify-jp-tfnotify-prod/google_project_service.tf line 6, in resource "google_project_service" "gcp_api_service":
-|  6: resource "google_project_service" "gcp_api_service" {
+|   on .terraform/modules/tfnotify-jp-tfnotify-prod/google_project_service.tf line 6, in resource "google_project_service" "gcp_api_service":
+|    6: resource "google_project_service" "gcp_api_service" {
 |
-`,
+|`,
 				ExitCode: 1,
 				Error:    nil,
 			},

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -86,7 +86,7 @@ can't guarantee that exactly these actions will be performed if
 "terraform apply" is subsequently run.
 `
 
-const planFailureResult = `
+const planFailureResult0_12 = `
 xxxxxxxxx
 xxxxxxxxx
 xxxxxxxxx
@@ -97,6 +97,19 @@ Error: Error refreshing state: 4 error(s) occurred:
 
 * google_sql_database.main: google_sql_database.main: Error reading SQL Database "main" in instance "main-master-instance": googleapi: Error 409: The instance or operation is not in an appropriate state to handle the request., invalidState
 * google_sql_user.proxyuser_main: 1 error(s) occurred:
+`
+
+const planFailureResult0_15 = `
+xxxxxxxxx
+xxxxxxxxx
+xxxxxxxxx
+
+| Error: Error refreshing state: 4 error(s) occurred:
+| 
+| * google_sql_database.main: 1 error(s) occurred:
+| 
+| * google_sql_database.main: google_sql_database.main: Error reading SQL Database "main" in instance "main-master-instance": googleapi: Error 409: The instance or operation is not in an appropriate state to handle the request., invalidState
+| * google_sql_user.proxyuser_main: 1 error(s) occurred:
 `
 
 const planNoChanges = `
@@ -300,7 +313,7 @@ google_dns_record_set.dev_tfnotifyapps_com: Refreshing state...
 Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
 `
 
-const applyFailureResult = `
+const applyFailureResult0_12 = `
 data.terraform_remote_state.teams_platform_development: Refreshing state...
 google_project.tfnotify_jp_tfnotify_prod: Refreshing state...
 google_project_services.tfnotify_jp_tfnotify_prod: Refreshing state...
@@ -329,6 +342,37 @@ Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for reques
    6: resource "google_project_service" "gcp_api_service" {
 
 
+`
+
+const applyFailureResult0_15 = `
+data.terraform_remote_state.teams_platform_development: Refreshing state...
+google_project.tfnotify_jp_tfnotify_prod: Refreshing state...
+google_project_services.tfnotify_jp_tfnotify_prod: Refreshing state...
+google_bigquery_dataset.gateway_access_log: Refreshing state...
+google_compute_global_address.reviews_web_tfnotify_in: Refreshing state...
+google_compute_global_address.chartmuseum_tfnotifyapps_com: Refreshing state...
+google_storage_bucket.chartmuseum: Refreshing state...
+google_storage_bucket.ark_tfnotify_prod: Refreshing state...
+google_compute_global_address.reviews_api_tfnotify_in: Refreshing state...
+google_logging_project_sink.gateway_access_log_bigquery_sink: Refreshing state...
+google_project_iam_member.gateway_access_log_bigquery_sink_writer_is_bigquery_data_editor: Refreshing state...
+aws_s3_bucket.terraform_backend: Refreshing state...
+aws_s3_bucket.teams_terraform_private_modules: Refreshing state...
+aws_iam_policy.datadog_aws_integration: Refreshing state...
+aws_iam_role.datadog_aws_integration: Refreshing state...
+aws_iam_user.teams_terraform: Refreshing state...
+aws_iam_user_policy.teams_terraform: Refreshing state...
+aws_iam_role_policy_attachment.datadog_aws_integration: Refreshing state...
+google_dns_managed_zone.tfnotifyapps_com: Refreshing state...
+google_dns_record_set.dev_tfnotifyapps_com: Refreshing state...
+
+
+| Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for request "Enable Project Services tfnotify-jp-tfnotify-prod: map[logging.googleapis.com:{}]" returned error: failed to send enable services request: googleapi: Error 403: The caller does not have permission, forbidden
+| 
+|   on .terraform/modules/tfnotify-jp-tfnotify-prod/google_project_service.tf line 6, in resource "google_project_service" "gcp_api_service":
+|    6: resource "google_project_service" "gcp_api_service" {
+|
+|
 `
 
 func TestDefaultParserParse(t *testing.T) {
@@ -429,7 +473,7 @@ func TestPlanParserParse(t *testing.T) {
 		},
 		{
 			name: "plan ng pattern",
-			body: planFailureResult,
+			body: planFailureResult0_12,
 			result: ParseResult{
 				Result: `Error: Error refreshing state: 4 error(s) occurred:
 
@@ -437,6 +481,24 @@ func TestPlanParserParse(t *testing.T) {
 
 * google_sql_database.main: google_sql_database.main: Error reading SQL Database "main" in instance "main-master-instance": googleapi: Error 409: The instance or operation is not in an appropriate state to handle the request., invalidState
 * google_sql_user.proxyuser_main: 1 error(s) occurred:`,
+				HasAddOrUpdateOnly: false,
+				HasDestroy:         false,
+				HasNoChanges:       false,
+				HasPlanError:       true,
+				ExitCode:           1,
+				Error:              nil,
+			},
+		},
+		{
+			name: "plan ng pattern",
+			body: planFailureResult0_15,
+			result: ParseResult{
+				Result: `| Error: Error refreshing state: 4 error(s) occurred:
+| 
+| * google_sql_database.main: 1 error(s) occurred:
+| 
+| * google_sql_database.main: google_sql_database.main: Error reading SQL Database "main" in instance "main-master-instance": googleapi: Error 409: The instance or operation is not in an appropriate state to handle the request., invalidState
+| * google_sql_user.proxyuser_main: 1 error(s) occurred:`,
 				HasAddOrUpdateOnly: false,
 				HasDestroy:         false,
 				HasNoChanges:       false,
@@ -532,13 +594,27 @@ func TestApplyParserParse(t *testing.T) {
 		},
 		{
 			name: "apply ng pattern",
-			body: applyFailureResult,
+			body: applyFailureResult0_12,
 			result: ParseResult{
 				Result: `Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for request "Enable Project Services tfnotify-jp-tfnotify-prod: map[logging.googleapis.com:{}]" returned error: failed to send enable services request: googleapi: Error 403: The caller does not have permission, forbidden
 
   on .terraform/modules/tfnotify-jp-tfnotify-prod/google_project_service.tf line 6, in resource "google_project_service" "gcp_api_service":
    6: resource "google_project_service" "gcp_api_service" {
 
+`,
+				ExitCode: 1,
+				Error:    nil,
+			},
+		},
+		{
+			name: "apply ng pattern",
+			body: applyFailureResult0_15,
+			result: ParseResult{
+				Result: `| Error: Batch "project/tfnotify-jp-tfnotify-prod/services:batchEnable" for request "Enable Project Services tfnotify-jp-tfnotify-prod: map[logging.googleapis.com:{}]" returned error: failed to send enable services request: googleapi: Error 403: The caller does not have permission, forbidden
+|
+| on .terraform/modules/tfnotify-jp-tfnotify-prod/google_project_service.tf line 6, in resource "google_project_service" "gcp_api_service":
+|  6: resource "google_project_service" "gcp_api_service" {
+|
 `,
 				ExitCode: 1,
 				Error:    nil,


### PR DESCRIPTION
## WHAT

I have supported Terraform version `>= 0.15`

## WHY

For https://github.com/mercari/tfnotify/issues/104.
Because `tfnotify` can't parse failure messages from `0.15`, we can't use it. Thus, this PR aims to support it.
