### PR TITLE
Add `_REGION` substitute to readme Cloud  Build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ GitHub private repositories require the `repo` and `write:discussion` permission
   - `BUILD_ID`
   - `PROJECT_ID`
   - `_PR_NUMBER`
+  - `_REGION`
 - Recommended trigger events
   - `terraform plan`: Pull request
   - `terraform apply`: Push to branch


### PR DESCRIPTION
## WHAT

As title.

## WHY

Context: https://github.com/mercari/tfnotify/issues/102
I added a variable lookup in the previous https://github.com/mercari/tfnotify/pull/101 but forgot to update the readme 🙏  
(The variable was renamed later https://github.com/mercari/tfnotify/pull/103)