### PR TITLE
Support custom GitHub token environment variable name

### DIFF
--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -10,9 +10,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// EnvToken is GitHub API Token
-const EnvToken = "GITHUB_TOKEN"
-
 // EnvBaseURL is GitHub base URL. This can be set to a domain endpoint to use with GitHub Enterprise.
 const EnvBaseURL = "GITHUB_BASE_URL"
 

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -69,10 +69,11 @@ type service struct {
 // NewClient returns Client initialized with Config
 func NewClient(cfg Config) (*Client, error) {
 	token := cfg.Token
-	token = strings.TrimPrefix(token, "$")
-	if token == EnvToken {
-		token = os.Getenv(EnvToken)
+
+	if strings.HasPrefix(token, "$") {
+		token = os.Getenv(strings.TrimPrefix(token, "$"))
 	}
+
 	if token == "" {
 		return &Client{}, errors.New("github token is missing")
 	}

--- a/notifier/github/client_test.go
+++ b/notifier/github/client_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -42,8 +43,20 @@ func TestNewClient(t *testing.T) {
 			expect:   "github token is missing",
 		},
 		{
+			// specify via env but not to be set env (part 3)
+			config:   Config{Token: "$TFNOTIFY_GITHUB_TOKEN"},
+			envToken: "",
+			expect:   "github token is missing",
+		},
+		{
 			// specify via env (part 2)
 			config:   Config{Token: "$GITHUB_TOKEN"},
+			envToken: "abcdefg",
+			expect:   "",
+		},
+		{
+			// specify via env (part 3)
+			config:   Config{Token: "$TFNOTIFY_GITHUB_TOKEN"},
 			envToken: "abcdefg",
 			expect:   "",
 		},
@@ -61,7 +74,13 @@ func TestNewClient(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		os.Setenv(EnvToken, testCase.envToken)
+		if strings.HasPrefix(testCase.config.Token, "$") {
+			key := strings.TrimPrefix(testCase.config.Token, "$")
+			os.Setenv(key, testCase.envToken)
+		} else {
+			os.Setenv(EnvToken, testCase.envToken)
+		}
+
 		_, err := NewClient(testCase.config)
 		if err == nil {
 			continue

--- a/notifier/github/client_test.go
+++ b/notifier/github/client_test.go
@@ -7,12 +7,6 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	githubToken := os.Getenv(EnvToken)
-	defer func() {
-		os.Setenv(EnvToken, githubToken)
-	}()
-	os.Setenv(EnvToken, "")
-
 	testCases := []struct {
 		config   Config
 		envToken string
@@ -77,8 +71,6 @@ func TestNewClient(t *testing.T) {
 		if strings.HasPrefix(testCase.config.Token, "$") {
 			key := strings.TrimPrefix(testCase.config.Token, "$")
 			os.Setenv(key, testCase.envToken)
-		} else {
-			os.Setenv(EnvToken, testCase.envToken)
 		}
 
 		_, err := NewClient(testCase.config)


### PR DESCRIPTION
## WHAT

If the token with `$` are configured, lookup the environment variable.

## WHY

For https://github.com/mercari/tfnotify/issues/111.
In current implementation, the `tfnotify` only supports `GITHUB_TOKEN` and users can't specify a environment variable of their own.