### PR TITLE
ci: use Go 1.16 to fix latest release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.x'
+          go-version: '1.16.x'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.14.x'
+          go-version: '1.16.x'
       - name: Checkout
         uses: actions/checkout@v2
       - name: Test


### PR DESCRIPTION
## WHAT

Use Go 1.16 to run tests and build release artifacts.

## WHY

This project has no explicit build target configuration and the latest goreleaser builds against darwin/arm64 by default. Thus, this project is built against darwin/arm64 now.

However, this project uses Go 1.14 to build the project that does not support darwin/arm64 build.

So the project's release workflow [has failed](https://github.com/mercari/tfnotify/runs/5883756728?check_suite_focus=true) and the latest change such as https://github.com/mercari/tfnotify/pull/77 is not released yet.
