### PR TITLE
shorten too long github comment

### DIFF
--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -2,8 +2,10 @@ package github
 
 import (
 	"context"
-	"github.com/mercari/tfnotify/terraform"
 	"net/http"
+	"unicode/utf8"
+
+	"github.com/mercari/tfnotify/terraform"
 )
 
 // NotifyService handles communication with the notification related
@@ -70,7 +72,7 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 		Link:         cfg.CI,
 		UseRawOutput: cfg.UseRawOutput,
 	})
-	body, err = template.Execute()
+	body, err = templateExecute(template)
 	if err != nil {
 		return result.ExitCode, err
 	}
@@ -113,7 +115,7 @@ func (g *NotifyService) notifyDestroyWarning(body string, result terraform.Parse
 		Link:         cfg.CI,
 		UseRawOutput: cfg.UseRawOutput,
 	})
-	body, err := destroyWarningTemplate.Execute()
+	body, err := templateExecute(destroyWarningTemplate)
 	if err != nil {
 		return err
 	}
@@ -143,4 +145,21 @@ func (g *NotifyService) removeResultLabels() error {
 	}
 
 	return nil
+}
+
+func templateExecute(template terraform.Template) (string, error) {
+	body, err := template.Execute()
+	if err != nil {
+		return "", err
+	}
+
+	if utf8.RuneCountInString(body) <= 65536 {
+		return body, nil
+	}
+
+	templateValues := template.GetValue()
+	templateValues.Body = "Body is too long. Please check the CI result."
+
+	template.SetValue(templateValues)
+	return template.Execute()
 }

--- a/notifier/github/notify_test.go
+++ b/notifier/github/notify_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mercari/tfnotify/terraform"
@@ -82,6 +83,24 @@ func TestNotifyNotify(t *testing.T) {
 				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
 			},
 			body:     "Plan: 1 to add",
+			ok:       true,
+			exitCode: 0,
+		},
+		{
+			// valid, isPR, and cannot comment details because body is too long
+			config: Config{
+				Token: "token",
+				Owner: "owner",
+				Repo:  "repo",
+				PR: PullRequest{
+					Revision: "",
+					Number:   1,
+					Message:  "message",
+				},
+				Parser:   terraform.NewPlanParser(),
+				Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
+			},
+			body:     fmt.Sprintf("Plan: 1 to add \n%065537s", "0"),
 			ok:       true,
 			exitCode: 0,
 		},


### PR DESCRIPTION
## WHAT

I shorten too long results commented to GitHub. 

## WHY

When you try to comment too long message, GitHub API will return error, and nothing is commented to PR.
```
POST https://api.github.com/repos/<owner>/<repo>/issues/<pr number>/comments: 422 Validation Failed [{Resource:IssueComment Field:data Code:unprocessable Message:Body is too long (maximum is 65536 characters)}]
```