### PR TITLE
feat: Support body from fmt command

### DIFF
--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -90,7 +90,7 @@ func (p *DefaultParser) Parse(body string) ParseResult {
 func (p *FmtParser) Parse(body string) ParseResult {
 	result := ParseResult{}
 	if p.Fail.MatchString(body) {
-		result.Result = "There is diff in your .tf file (need to be formatted)"
+		result.Result = body
 		result.ExitCode = ExitFail
 	}
 	return result

--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -90,7 +90,7 @@ func (p *DefaultParser) Parse(body string) ParseResult {
 func (p *FmtParser) Parse(body string) ParseResult {
 	result := ParseResult{}
 	if p.Fail.MatchString(body) {
-		result.Result = body
+		result.Result = "There is diff in your .tf file (need to be formatted)"
 		result.ExitCode = ExitFail
 	}
 	return result

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -241,8 +241,8 @@ func (t *FmtTemplate) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":   t.Title,
 		"Message": t.Message,
-		"Result":  "",
-		"Body":    t.Result,
+		"Result":  t.Result,
+		"Body":    t.Body,
 		"Link":    t.Link,
 	}
 

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -39,11 +39,10 @@ const (
 	DefaultFmtTemplate = `
 {{ .Title }}
 
-{{ .Message }}
+<details><summary>Details (Click me)</summary>
 
-{{ .Result }}
-
-{{ .Body }}
+<pre><code>{{ .Body }}
+</pre></code></details>
 `
 
 	// DefaultPlanTemplate is a default template for terraform plan

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -39,10 +39,17 @@ const (
 	DefaultFmtTemplate = `
 {{ .Title }}
 
+{{ .Message }}
+
+{{if .Result}}
+<pre><code>{{ .Result }}
+</code></pre>
+{{end}}
+
 <details><summary>Details (Click me)</summary>
 
 <pre><code>{{ .Body }}
-</pre></code></details>
+</code></pre></details>
 `
 
 	// DefaultPlanTemplate is a default template for terraform plan

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -66,7 +66,6 @@ b
 </code></pre></details>
 `,
 		},
-
 		{
 			template: "",
 			value: CommonTemplate{
@@ -193,7 +192,10 @@ func TestFmtTemplateExecute(t *testing.T) {
 
 
 
+<details><summary>Details (Click me)</summary>
 
+<pre><code>
+</code></pre></details>
 `,
 		},
 		{
@@ -208,7 +210,10 @@ message
 
 
 
+<details><summary>Details (Click me)</summary>
 
+<pre><code>
+</code></pre></details>
 `,
 		},
 		{
@@ -225,11 +230,16 @@ a
 b
 
 
+<pre><code>c
+</code></pre>
 
-c
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>d
+</code></pre></details>
 `,
 		},
-
 		{
 			template: "",
 			value: CommonTemplate{
@@ -244,8 +254,14 @@ a
 b
 
 
+<pre><code>c
+</code></pre>
 
-c
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>d
+</code></pre></details>
 `,
 		},
 		{
@@ -262,8 +278,14 @@ a
 b
 
 
+<pre><code>This is a &#34;result&#34;.
+</code></pre>
 
-This is a &#34;result&#34;.
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>d
+</code></pre></details>
 `,
 		},
 		{
@@ -281,8 +303,14 @@ a
 b
 
 
+<pre><code>This is a "result".
+</code></pre>
 
-This is a "result".
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>d
+</code></pre></details>
 `,
 		},
 		{
@@ -290,10 +318,10 @@ This is a "result".
 			value: CommonTemplate{
 				Title:   "a",
 				Message: "b",
-				Result:  "should be used as body",
-				Body:    "should be empty",
+				Result:  "c",
+				Body:    "d",
 			},
-			resp: `a-b--should be used as body`,
+			resp: `a-b-c-d`,
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
## WHAT

Instead of just printing:
`"There is diff in your .tf file (need to be formatted)"`

I'm sending the full body:
![image](https://user-images.githubusercontent.com/8814890/206284616-5f47b082-708a-4bad-8e35-c42db0a9dc9a.png)


## WHY

We want to let the user know what the problem was.
