### PR TITLE
Support the use raw ouput option for GitLab

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,9 +143,10 @@ func (t *tfnotify) Run() error {
 				Title:    t.context.String("title"),
 				Message:  t.context.String("message"),
 			},
-			CI:       ci.URL,
-			Parser:   t.parser,
-			Template: t.template,
+			CI:           ci.URL,
+			Parser:       t.parser,
+			Template:     t.template,
+			UseRawOutput: t.config.Terraform.UseRawOutput,
 		})
 		if err != nil {
 			return err

--- a/notifier/gitlab/client.go
+++ b/notifier/gitlab/client.go
@@ -33,14 +33,15 @@ type Client struct {
 
 // Config is a configuration for GitHub client
 type Config struct {
-	Token     string
-	BaseURL   string
-	NameSpace string
-	Project   string
-	MR        MergeRequest
-	CI        string
-	Parser    terraform.Parser
-	Template  terraform.Template
+	Token        string
+	BaseURL      string
+	NameSpace    string
+	Project      string
+	MR           MergeRequest
+	CI           string
+	Parser       terraform.Parser
+	Template     terraform.Template
+	UseRawOutput bool
 }
 
 // MergeRequest represents GitLab Merge Request metadata

--- a/notifier/gitlab/notify.go
+++ b/notifier/gitlab/notify.go
@@ -23,11 +23,12 @@ func (g *NotifyService) Notify(body string) (exit int, err error) {
 	}
 
 	template.SetValue(terraform.CommonTemplate{
-		Title:   cfg.MR.Title,
-		Message: cfg.MR.Message,
-		Result:  result.Result,
-		Body:    body,
-		Link:    cfg.CI,
+		Title:        cfg.MR.Title,
+		Message:      cfg.MR.Message,
+		Result:       result.Result,
+		Body:         body,
+		Link:         cfg.CI,
+		UseRawOutput: cfg.UseRawOutput,
 	})
 	body, err = template.Execute()
 	if err != nil {


### PR DESCRIPTION
## WHAT

Adds support for use raw output option in GitLab.

## WHY

If the difference display is escaped, it is difficult to review on the merge request.

## Related

https://github.com/mercari/tfnotify/pull/99
