### PR TITLE
Consolidation mode and Slack Notification Update patch v1.1.11

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"text/template"
 	"strconv"
+	"text/template"
 
 	"github.com/mercari/tfnotify/v1/pkg/config"
 	"github.com/mercari/tfnotify/v1/pkg/notifier"
@@ -130,6 +130,20 @@ func (c *Controller) renderGitHubLabels() (github.ResultLabels, error) { //nolin
 	return labels, nil
 }
 
+// parseBoolEnv returns the boolean value of the environment variable name.
+// If the variable is unset or empty, def is returned.
+func parseBoolEnv(name string, def bool) (bool, error) {
+	s := os.Getenv(name)
+	if s == "" {
+		return def, nil
+	}
+	parsed, err := strconv.ParseBool(s)
+	if err != nil {
+		return def, fmt.Errorf("invalid %s value %q: %w", name, s, err)
+	}
+	return parsed, nil
+}
+
 func (c *Controller) getPlanNotifier(ctx context.Context) ([]notifier.Notifier, error) {
 	var notifiers []notifier.Notifier
 
@@ -151,35 +165,25 @@ func (c *Controller) getPlanNotifier(ctx context.Context) ([]notifier.Notifier, 
 				planMessage = envMessage
 			}
 
-			var useThreads bool
+			// Threads are enabled by default; config and env var can override
+			useThreads := true
 			if c.Config.Slack.UseThreads != nil {
 				useThreads = *c.Config.Slack.UseThreads
 			}
-
-			if s, ok := os.LookupEnv("SLACK_USE_THREADS"); ok {
-			    parsed, err := strconv.ParseBool(s)
-			    if err != nil {
-			        return nil, fmt.Errorf("invalid SLACK_USE_THREADS value %q: %w", s, err)
-			    }
-			    useThreads = parsed
+			var err error
+			useThreads, err = parseBoolEnv("SLACK_USE_THREADS", useThreads)
+			if err != nil {
+				return nil, err
 			}
 
-			notifyOnPlanError := c.Config.Slack.NotifyOnPlanError
-			if envNotifyOnPlanError := os.Getenv("SLACK_NOTIFY_ON_PLAN_ERROR"); envNotifyOnPlanError != "false" {
-				parsed, err := strconv.ParseBool(envNotifyOnPlanError)
-				if err != nil {
-					return nil, fmt.Errorf("invalid SLACK_NOTIFY_ON_PLAN_ERROR value %q: %w", envNotifyOnPlanError, err)
-				}
-				notifyOnPlanError = parsed
+			notifyOnPlanError, err := parseBoolEnv("SLACK_NOTIFY_ON_PLAN_ERROR", c.Config.Slack.NotifyOnPlanError)
+			if err != nil {
+				return nil, err
 			}
 
-			notifyOnApplyError := c.Config.Slack.NotifyOnApplyError
-			if envNotifyOnApplyError := os.Getenv("SLACK_NOTIFY_ON_APPLY_ERROR"); envNotifyOnApplyError != "false" {
-				parsed, err := strconv.ParseBool(envNotifyOnApplyError)
-				if err != nil {
-					return nil, fmt.Errorf("invalid SLACK_NOTIFY_ON_APPLY_ERROR value %q: %w", envNotifyOnApplyError, err)
-				}
-				notifyOnApplyError = parsed
+			notifyOnApplyError, err := parseBoolEnv("SLACK_NOTIFY_ON_APPLY_ERROR", c.Config.Slack.NotifyOnApplyError)
+			if err != nil {
+				return nil, err
 			}
 
 			client, err := slack.NewClient(&slack.Config{
@@ -242,7 +246,6 @@ func (c *Controller) getPlanNotifier(ctx context.Context) ([]notifier.Notifier, 
 			IgnoreWarning:      c.Config.Terraform.Plan.IgnoreWarning,
 			Masks:              c.Config.Masks,
 		})
-		// Fix for getPlanNotifier
 		if err != nil {
 			return nil, err
 		}
@@ -273,34 +276,25 @@ func (c *Controller) getApplyNotifier(ctx context.Context) ([]notifier.Notifier,
 				applyMessage = envMessage
 			}
 
+			// Threads are enabled by default; config and env var can override
 			useThreads := true
 			if c.Config.Slack.UseThreads != nil {
 				useThreads = *c.Config.Slack.UseThreads
 			}
-			if envUseThreads := os.Getenv("SLACK_USE_THREADS"); envUseThreads != "" {
-				parsed, err := strconv.ParseBool(envUseThreads)
-				if err != nil {
-					return nil, fmt.Errorf("invalid SLACK_USE_THREADS value %q: %w", envUseThreads, err)
-				}
-				useThreads = parsed
+			var err error
+			useThreads, err = parseBoolEnv("SLACK_USE_THREADS", useThreads)
+			if err != nil {
+				return nil, err
 			}
 
-			notifyOnPlanError := c.Config.Slack.NotifyOnPlanError
-			if envNotifyOnPlanError := os.Getenv("SLACK_NOTIFY_ON_PLAN_ERROR"); envNotifyOnPlanError != "" {
-				parsed, err := strconv.ParseBool(envNotifyOnPlanError)
-				if err != nil {
-					return nil, fmt.Errorf("invalid SLACK_NOTIFY_ON_PLAN_ERROR value %q: %w", envNotifyOnPlanError, err)
-				}
-				notifyOnPlanError = parsed
+			notifyOnPlanError, err := parseBoolEnv("SLACK_NOTIFY_ON_PLAN_ERROR", c.Config.Slack.NotifyOnPlanError)
+			if err != nil {
+				return nil, err
 			}
 
-			notifyOnApplyError := c.Config.Slack.NotifyOnApplyError
-			if envNotifyOnApplyError := os.Getenv("SLACK_NOTIFY_ON_APPLY_ERROR"); envNotifyOnApplyError != "" {
-				parsed, err := strconv.ParseBool(envNotifyOnApplyError)
-				if err != nil {
-					return nil, fmt.Errorf("invalid SLACK_NOTIFY_ON_APPLY_ERROR value %q: %w", envNotifyOnApplyError, err)
-				}
-				notifyOnApplyError = parsed
+			notifyOnApplyError, err := parseBoolEnv("SLACK_NOTIFY_ON_APPLY_ERROR", c.Config.Slack.NotifyOnApplyError)
+			if err != nil {
+				return nil, err
 			}
 
 			client, err := slack.NewClient(&slack.Config{

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"testing"
+)
+
+func TestParseBoolEnv(t *testing.T) { //nolint:paralleltest
+	tests := []struct {
+		name    string
+		value   string
+		set     bool
+		def     bool
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset returns default false", set: false, def: false, want: false},
+		{name: "unset returns default true", set: false, def: true, want: true},
+		{name: "empty returns default", set: true, value: "", def: true, want: true},
+		{name: "true overrides default", set: true, value: "true", def: false, want: true},
+		{name: "false overrides default", set: true, value: "false", def: true, want: false},
+		{name: "invalid value returns error", set: true, value: "yes please", def: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const envName = "TFNOTIFY_TEST_BOOL_ENV"
+			if tt.set {
+				t.Setenv(envName, tt.value)
+			}
+
+			got, err := parseBoolEnv(envName, tt.def)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseBoolEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/notifier/github/apply.go
+++ b/pkg/notifier/github/apply.go
@@ -107,6 +107,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) er
 		UpdatedResources:       result.UpdatedResources,
 		DeletedResources:       result.DeletedResources,
 		ReplacedResources:      result.ReplacedResources,
+		ModuleResults:          result.ModuleResults,
 		AISummary:              aiSummary,
 		SummaryEnabled:         param.AISummarizer != nil,
 	})

--- a/pkg/notifier/github/plan.go
+++ b/pkg/notifier/github/plan.go
@@ -116,6 +116,7 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) err
 		ReplacedResources:      result.ReplacedResources,
 		MovedResources:         result.MovedResources,
 		ImportedResources:      result.ImportedResources,
+		ModuleResults:          result.ModuleResults,
 		AISummary:              aiSummary,
 		SummaryEnabled:         param.AISummarizer != nil,
 	})

--- a/pkg/notifier/localfile/apply.go
+++ b/pkg/notifier/localfile/apply.go
@@ -100,6 +100,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) er
 		UpdatedResources:       result.UpdatedResources,
 		DeletedResources:       result.DeletedResources,
 		ReplacedResources:      result.ReplacedResources,
+		ModuleResults:          result.ModuleResults,
 		AISummary:              aiSummary,
 		SummaryEnabled:         param.AISummarizer != nil,
 	})

--- a/pkg/notifier/localfile/plan.go
+++ b/pkg/notifier/localfile/plan.go
@@ -109,6 +109,7 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) err
 		ReplacedResources:      result.ReplacedResources,
 		MovedResources:         result.MovedResources,
 		ImportedResources:      result.ImportedResources,
+		ModuleResults:          result.ModuleResults,
 		AISummary:              aiSummary,
 		SummaryEnabled:         param.AISummarizer != nil,
 	})

--- a/pkg/notifier/slack/apply.go
+++ b/pkg/notifier/slack/apply.go
@@ -88,6 +88,7 @@ func (s *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) er
 		UpdatedResources:       result.UpdatedResources,
 		DeletedResources:       result.DeletedResources,
 		ReplacedResources:      result.ReplacedResources,
+		ModuleResults:          result.ModuleResults,
 		AISummary:              aiSummary,
 		SummaryEnabled:         param.AISummarizer != nil,
 	})

--- a/pkg/notifier/slack/apply.go
+++ b/pkg/notifier/slack/apply.go
@@ -136,14 +136,7 @@ func (s *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) er
 	// If using threads, send parent message then error details in thread
 	if cfg.UseThreads {
 		// Send parent summary message
-		parentMessage := ""
-		if title != "" {
-			parentMessage = fmt.Sprintf("*%s*\n\n", title)
-		}
-		if message != "" {
-			parentMessage += fmt.Sprintf("%s\n\n", message)
-		}
-		parentMessage += "❌ Terraform apply failed. See thread for details."
+		parentMessage := buildParentMessage(title, message, "❌ Terraform apply failed. See thread for details.")
 
 		logrus.Info("Sending parent message to Slack")
 		timestamp, err := s.postMessageAndGetTimestamp(ctx, parentMessage, nil)
@@ -151,7 +144,7 @@ func (s *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) er
 			return err
 		}
 
-		threadMessage := fmt.Sprintf("```\n%s\n```", result.Result)
+		threadMessage := buildThreadMessage(result.Result)
 		logrus.WithField("parent_ts", timestamp).Info("Sending error details in thread")
 		return s.postMessage(ctx, threadMessage, &timestamp)
 	}
@@ -173,7 +166,7 @@ func (s *NotifyService) postMessageAndGetTimestamp(ctx context.Context, text str
 
 	// Build message options
 	options := []slackgo.MsgOption{
-		slackgo.MsgOptionText(text, false),
+		slackgo.MsgOptionText(truncateForSlack(text), false),
 	}
 
 	// Set bot name if configured

--- a/pkg/notifier/slack/plan.go
+++ b/pkg/notifier/slack/plan.go
@@ -139,14 +139,7 @@ func (s *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) err
 	// If using threads, send parent message then error details in thread
 	if cfg.UseThreads && param.ExitCode != 0 {
 		// Send parent summary message
-		parentMessage := fullMessage
-		if title != "" {
-			parentMessage = fmt.Sprintf("*%s*\n\n", title)
-		}
-		if message != "" {
-			parentMessage += fmt.Sprintf("%s\n\n", message)
-		}
-		parentMessage += "❌ Terraform plan failed. See thread for details."
+		parentMessage := buildParentMessage(title, message, "❌ Terraform plan failed. See thread for details.")
 
 		logrus.Info("Sending parent message to Slack")
 		timestamp, err := s.postMessageAndGetTimestamp(ctx, parentMessage, nil)
@@ -154,7 +147,7 @@ func (s *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) err
 			return err
 		}
 
-		threadMessage := fmt.Sprintf("```\n%s\n```", result.Result)
+		threadMessage := buildThreadMessage(result.Result)
 		logrus.WithField("parent_ts", timestamp).Info("Sending error details in thread")
 		return s.postMessage(ctx, threadMessage, &timestamp)
 	}

--- a/pkg/notifier/slack/plan.go
+++ b/pkg/notifier/slack/plan.go
@@ -86,6 +86,7 @@ func (s *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) err
 		UpdatedResources:       result.UpdatedResources,
 		DeletedResources:       result.DeletedResources,
 		ReplacedResources:      result.ReplacedResources,
+		ModuleResults:          result.ModuleResults,
 		AISummary:              aiSummary,
 		SummaryEnabled:         param.AISummarizer != nil,
 	})

--- a/pkg/notifier/slack/slack.go
+++ b/pkg/notifier/slack/slack.go
@@ -18,6 +18,45 @@ func escapeSlackText(text string) string {
 	return text
 }
 
+// slackMaxTextLength is the maximum length of a Slack message text field.
+// Slack rejects messages longer than 40,000 characters.
+const slackMaxTextLength = 40000
+
+// truncateForSlack truncates text so it fits in a single Slack message
+func truncateForSlack(text string) string {
+	if len(text) <= slackMaxTextLength {
+		return text
+	}
+	const note = "\n... (output truncated by tfnotify)"
+	return text[:slackMaxTextLength-len(note)] + note
+}
+
+// buildParentMessage builds the parent (summary) message of a thread
+func buildParentMessage(title, message, status string) string {
+	parent := ""
+	if title != "" {
+		parent = fmt.Sprintf("*%s*\n\n", title)
+	}
+	if message != "" {
+		parent += fmt.Sprintf("%s\n\n", message)
+	}
+	return parent + status
+}
+
+// buildThreadMessage wraps the result details in a code block for a thread reply
+func buildThreadMessage(details string) string {
+	if details == "" {
+		details = "(no output captured)"
+	}
+	// Leave room for the code fences and the truncation note so the
+	// closing fence is never cut off.
+	const overhead = 50
+	if len(details) > slackMaxTextLength-overhead {
+		details = details[:slackMaxTextLength-overhead] + "\n... (output truncated by tfnotify)"
+	}
+	return fmt.Sprintf("```\n%s\n```", details)
+}
+
 // Client is a Slack client
 type Client struct {
 	*slackgo.Client

--- a/pkg/notifier/slack/slack_test.go
+++ b/pkg/notifier/slack/slack_test.go
@@ -1,0 +1,187 @@
+package slack
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mercari/tfnotify/v1/pkg/notifier"
+	"github.com/mercari/tfnotify/v1/pkg/terraform"
+)
+
+// newTestClient builds a Slack client that would fail loudly if any API call
+// were attempted (invalid token), so tests can assert that no message is sent.
+func newTestClient(t *testing.T, cfg *Config) *Client {
+	t.Helper()
+	cfg.Token = "xoxb-test-invalid"
+	cfg.ChannelID = "C0000000000"
+	if cfg.Parser == nil {
+		cfg.Parser = terraform.NewPlanParser()
+	}
+	if cfg.Template == nil {
+		cfg.Template = terraform.NewPlanTemplate("")
+	}
+	if cfg.ParseErrorTemplate == nil {
+		cfg.ParseErrorTemplate = terraform.NewPlanParseErrorTemplate("")
+	}
+	if cfg.Vars == nil {
+		cfg.Vars = map[string]string{}
+	}
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	return client
+}
+
+const failedPlanOutput = `Error: Invalid configuration
+
+Something went wrong`
+
+// TestPlanDisabledNeverPosts guards against threads being sent when plan
+// notifications are disabled (regression test).
+func TestPlanDisabledNeverPosts(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, &Config{
+		NotifyOnPlanError: false, // plan notifications disabled
+		UseThreads:        true,  // threads enabled must not matter
+	})
+
+	err := client.Notify().Plan(context.Background(), &notifier.ParamExec{
+		CombinedOutput: failedPlanOutput,
+		ExitCode:       1,
+	})
+	// Any attempted Slack API call would fail with an auth error here,
+	// so a nil error proves nothing was posted.
+	if err != nil {
+		t.Errorf("Plan() with notifications disabled posted to Slack: %v", err)
+	}
+}
+
+// TestPlanSucceededNeverThreads ensures successful plans don't post threads
+// even when notify_on_plan_error and threads are enabled.
+func TestPlanSucceededNeverThreads(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, &Config{
+		NotifyOnPlanError: true,
+		UseThreads:        true,
+	})
+
+	err := client.Notify().Plan(context.Background(), &notifier.ParamExec{
+		CombinedOutput: "Plan: 1 to add, 0 to change, 0 to destroy.",
+		ExitCode:       0,
+	})
+	if err != nil {
+		t.Errorf("Plan() with exit code 0 posted to Slack: %v", err)
+	}
+}
+
+// TestApplyDisabledNeverPosts mirrors the plan test for the apply path.
+func TestApplyDisabledNeverPosts(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, &Config{
+		NotifyOnApplyError: false,
+		UseThreads:         true,
+		Parser:             terraform.NewApplyParser(),
+		Template:           terraform.NewApplyTemplate(""),
+		ParseErrorTemplate: terraform.NewApplyParseErrorTemplate(""),
+	})
+
+	err := client.Notify().Apply(context.Background(), &notifier.ParamExec{
+		CombinedOutput: failedPlanOutput,
+		ExitCode:       1,
+	})
+	if err != nil {
+		t.Errorf("Apply() with notifications disabled posted to Slack: %v", err)
+	}
+}
+
+func TestBuildParentMessage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		title   string
+		message string
+		status  string
+		want    string
+	}{
+		{
+			name:    "title and message",
+			title:   "Plan Result",
+			message: "service-a",
+			status:  "failed",
+			want:    "*Plan Result*\n\nservice-a\n\nfailed",
+		},
+		{
+			name:   "title only",
+			title:  "Plan Result",
+			status: "failed",
+			want:   "*Plan Result*\n\nfailed",
+		},
+		{
+			name:   "status only",
+			status: "failed",
+			want:   "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildParentMessage(tt.title, tt.message, tt.status)
+			if got != tt.want {
+				t.Errorf("buildParentMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildThreadMessage(t *testing.T) {
+	t.Parallel()
+
+	got := buildThreadMessage("Error: something broke")
+	want := "```\nError: something broke\n```"
+	if got != want {
+		t.Errorf("buildThreadMessage() = %q, want %q", got, want)
+	}
+
+	// Empty details should still produce a valid code block
+	got = buildThreadMessage("")
+	if !strings.Contains(got, "(no output captured)") {
+		t.Errorf("buildThreadMessage(\"\") = %q, want placeholder text", got)
+	}
+
+	// Very long details must be truncated but keep the closing fence
+	long := strings.Repeat("x", slackMaxTextLength+1000)
+	got = buildThreadMessage(long)
+	if len(got) > slackMaxTextLength {
+		t.Errorf("buildThreadMessage() length = %d, exceeds Slack limit %d", len(got), slackMaxTextLength)
+	}
+	if !strings.HasSuffix(got, "\n```") {
+		t.Errorf("buildThreadMessage() truncated message does not end with closing code fence: %q", got[len(got)-30:])
+	}
+	if !strings.Contains(got, "output truncated") {
+		t.Error("buildThreadMessage() truncated message missing truncation note")
+	}
+}
+
+func TestTruncateForSlack(t *testing.T) {
+	t.Parallel()
+
+	short := "hello"
+	if got := truncateForSlack(short); got != short {
+		t.Errorf("truncateForSlack(short) = %q, want unchanged", got)
+	}
+
+	long := strings.Repeat("y", slackMaxTextLength+5000)
+	got := truncateForSlack(long)
+	if len(got) > slackMaxTextLength {
+		t.Errorf("truncateForSlack() length = %d, exceeds limit %d", len(got), slackMaxTextLength)
+	}
+	if !strings.Contains(got, "output truncated") {
+		t.Error("truncateForSlack() missing truncation note")
+	}
+}

--- a/pkg/terraform/parser.go
+++ b/pkg/terraform/parser.go
@@ -31,6 +31,26 @@ type ParseResult struct {
 	ReplacedResources  []string
 	MovedResources     []*MovedResource
 	ImportedResources  []string
+	// ModuleResults is populated only by TerragruntParser when Consolidated=true
+	// and the parsed body contains 2+ modules (or at least one named module).
+	// Consumer templates can use this to render a per-module Create/Update/etc
+	// summary instead of the flat global lists. Nil otherwise; templates should
+	// fall back to the flat lists when nil.
+	ModuleResults []*ModuleResult
+}
+
+// ModuleResult is the per-module breakdown of resource changes in a
+// consolidated Terragrunt run. The Module field carries the module path as
+// seen in the run-all output (e.g. `cluster-citadel-2g/regions/tokyo/shared-vpc`).
+// Root-module changes are labeled "Root module".
+type ModuleResult struct {
+	Module             string
+	CreatedResources   []string
+	UpdatedResources   []string
+	DeletedResources   []string
+	ReplacedResources  []string
+	MovedResources     []*MovedResource
+	ImportedResources  []string
 }
 
 // PlanParser is a parser for terraform plan
@@ -422,6 +442,21 @@ func (p *TerragruntParser) ParseWithConsolidation(body string, consolidated bool
 		return sec
 	}
 
+	// Per-module Create/Update/etc buckets, in order of first appearance.
+	// Mirrors the flat all*Resources slices but keyed by module so consumer
+	// templates can render a per-module summary in consolidated mode.
+	var moduleResults []*ModuleResult
+	moduleResultIndex := map[string]int{}
+	getModuleResult := func(name string) *ModuleResult {
+		if idx, ok := moduleResultIndex[name]; ok {
+			return moduleResults[idx]
+		}
+		mr := &ModuleResult{Module: name}
+		moduleResultIndex[name] = len(moduleResults)
+		moduleResults = append(moduleResults, mr)
+		return mr
+	}
+
 	currentModule := ""
 
 	for i, line := range lines {
@@ -502,31 +537,44 @@ func (p *TerragruntParser) ParseWithConsolidation(body string, consolidated bool
 			}
 		}
 
-		// Extract resources
+		// Extract resources. Each match goes to both the flat global slice and
+		// the per-module bucket (the latter drives per-module rendering in
+		// consolidated mode; flat slices stay for templates that haven't migrated).
+		mr := getModuleResult(currentModule)
 		if rsc := extractResource(p.Create, line); rsc != "" {
 			allCreatedResources = append(allCreatedResources, rsc)
+			mr.CreatedResources = append(mr.CreatedResources, rsc)
 		} else if rsc := extractResource(p.Update, line); rsc != "" {
 			allUpdatedResources = append(allUpdatedResources, rsc)
+			mr.UpdatedResources = append(mr.UpdatedResources, rsc)
 		} else if rsc := extractResource(p.Delete, line); rsc != "" {
 			allDeletedResources = append(allDeletedResources, rsc)
+			mr.DeletedResources = append(mr.DeletedResources, rsc)
 		} else if rsc := extractResource(p.Replace, line); rsc != "" {
 			allReplacedResources = append(allReplacedResources, rsc)
+			mr.ReplacedResources = append(mr.ReplacedResources, rsc)
 		} else if rsc := extractResource(p.ReplaceOption, line); rsc != "" {
 			allReplacedResources = append(allReplacedResources, rsc)
+			mr.ReplacedResources = append(mr.ReplacedResources, rsc)
 		} else if rsc := extractResource(p.Import, line); rsc != "" {
 			allImportedResources = append(allImportedResources, rsc)
+			mr.ImportedResources = append(mr.ImportedResources, rsc)
 		} else if rsc := extractResource(p.ImportedFrom, line); rsc != "" {
 			if i > 0 {
 				if toRsc := p.changedResources(lines[i-1]); toRsc != "" {
 					allImportedResources = append(allImportedResources, toRsc)
+					mr.ImportedResources = append(mr.ImportedResources, toRsc)
 				}
 			}
 		} else if rsc := extractMovedResource(p.Move, line); rsc != nil {
 			allMovedResources = append(allMovedResources, rsc)
+			mr.MovedResources = append(mr.MovedResources, rsc)
 		} else if fromRsc := extractResource(p.MovedFrom, line); fromRsc != "" {
 			if i > 0 {
 				if toRsc := p.changedResources(lines[i-1]); toRsc != "" {
-					allMovedResources = append(allMovedResources, &MovedResource{Before: fromRsc, After: toRsc})
+					mvd := &MovedResource{Before: fromRsc, After: toRsc}
+					allMovedResources = append(allMovedResources, mvd)
+					mr.MovedResources = append(mr.MovedResources, mvd)
 				}
 			}
 		}
@@ -579,6 +627,35 @@ func (p *TerragruntParser) ParseWithConsolidation(body string, consolidated bool
 
 	hasAddOrUpdateOnly := !hasNoChanges && !hasDestroy && !hasError
 
+	// Build ModuleResults only in consolidated mode and only when we have
+	// something useful to render. "Useful" = at least one named module with
+	// changes, OR multiple modules with changes (so the per-module split adds
+	// signal even if all are unnamed). Single-unnamed-module input falls
+	// through to the flat lists.
+	var emitModuleResults []*ModuleResult
+	if consolidated {
+		namedWithChanges := 0
+		withChanges := make([]*ModuleResult, 0, len(moduleResults))
+		for _, mr := range moduleResults {
+			if len(mr.CreatedResources)+len(mr.UpdatedResources)+len(mr.DeletedResources)+
+				len(mr.ReplacedResources)+len(mr.MovedResources)+len(mr.ImportedResources) == 0 {
+				continue
+			}
+			withChanges = append(withChanges, mr)
+			if mr.Module != "" {
+				namedWithChanges++
+			}
+		}
+		if namedWithChanges > 0 || len(withChanges) > 1 {
+			for _, mr := range withChanges {
+				if mr.Module == "" {
+					mr.Module = "Root module"
+				}
+			}
+			emitModuleResults = withChanges
+		}
+	}
+
 	return ParseResult{
 		Result:             strings.TrimSpace(result),
 		ChangedResult:      strings.Join(changeResults, "\n\n"),
@@ -594,6 +671,7 @@ func (p *TerragruntParser) ParseWithConsolidation(body string, consolidated bool
 		ReplacedResources:  allReplacedResources,
 		MovedResources:     allMovedResources,
 		ImportedResources:  allImportedResources,
+		ModuleResults:      emitModuleResults,
 	}
 }
 

--- a/pkg/terraform/parser.go
+++ b/pkg/terraform/parser.go
@@ -2,7 +2,9 @@ package terraform
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -74,6 +76,10 @@ type TerragruntParser struct {
 	ImportedFrom   *regexp.Regexp
 	MovedFrom      *regexp.Regexp
 	ModuleHeader   *regexp.Regexp
+	LogModule      *regexp.Regexp
+	PlanSummary    *regexp.Regexp
+	ApplySummary   *regexp.Regexp
+	ActionHeader   *regexp.Regexp
 	Consolidated   bool
 }
 
@@ -115,7 +121,7 @@ func NewTerragruntParser(consolidated bool) *TerragruntParser {
 	prefix := `(?:\d{2}:\d{2}:\d{2}\.\d{3} (?:STDOUT|STDERR|INFO|ERROR)\s+(?:\[.*?\]\s+)?(?:tfwrapper\.sh|terraform|tf):\s*)?`
 
 	return &TerragruntParser{
-		Pass:           regexp.MustCompile(`(?m)^` + prefix + `(Plan: \d|No changes\.)`),
+		Pass:           regexp.MustCompile(`(?m)^` + prefix + `(Plan: \d|No changes\.|Apply complete!)`),
 		Fail:           regexp.MustCompile(`(?m)^` + prefix + `([│|╵] )?(Error: )`),
 		Warning:        regexp.MustCompile(`(?m)^` + prefix + `([│|╵] )?(Warning: )`),
 		OutputsChanges: regexp.MustCompile(`(?m)^` + prefix + `Changes to Outputs:`),
@@ -131,6 +137,10 @@ func NewTerragruntParser(consolidated bool) *TerragruntParser {
 		ImportedFrom:   regexp.MustCompile(`^` + prefix + ` *# \(imported from (.*?)\)$`),
 		MovedFrom:      regexp.MustCompile(`^` + prefix + ` *# \(moved from (.*?)\)$`),
 		ModuleHeader:   regexp.MustCompile(`^(?:(?:Group \d+)|(?:- )?Module) (.+?)(?:\s+\[run-all\])?$`),
+		LogModule:      regexp.MustCompile(`^\d{2}:\d{2}:\d{2}\.\d{3} (?:STDOUT|STDERR|INFO|ERROR)\s+\[(.+?)\]\s`),
+		PlanSummary:    regexp.MustCompile(`^Plan: (?:(\d+) to import, )?(\d+) to add, (\d+) to change, (\d+) to destroy\.`),
+		ApplySummary:   regexp.MustCompile(`^Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed\.`),
+		ActionHeader:   regexp.MustCompile(`^(?:Terraform|OpenTofu) will perform the following actions:$`),
 		Consolidated:   consolidated,
 	}
 }
@@ -364,9 +374,16 @@ func (p *TerragruntParser) Parse(body string) ParseResult {
 	return p.ParseWithConsolidation(body, p.Consolidated)
 }
 
+// moduleSection holds the captured plan/apply output of a single terragrunt module
+type moduleSection struct {
+	name      string
+	lines     []string
+	capturing bool
+}
+
 // ParseWithConsolidation returns ParseResult with optional consolidation
-// If consolidated=true, all modules are combined into a single result
-func (p *TerragruntParser) ParseWithConsolidation(body string, consolidated bool) ParseResult { //nolint:cyclop,maintidx
+// If consolidated=true, module names are included as section headers in ChangedResult
+func (p *TerragruntParser) ParseWithConsolidation(body string, consolidated bool) ParseResult { //nolint:cyclop,maintidx,gocognit,funlen
 	switch {
 	case p.Fail.MatchString(body):
 	case p.Pass.MatchString(body) || p.OutputsChanges.MatchString(body):
@@ -379,172 +396,193 @@ func (p *TerragruntParser) ParseWithConsolidation(body string, consolidated bool
 	}
 
 	lines := strings.Split(body, "\n")
-	var result string
+
 	var allCreatedResources, allUpdatedResources, allDeletedResources, allReplacedResources, allImportedResources []string
 	var allMovedResources []*MovedResource
-	var hasDestroy, hasNoChanges, hasError bool
-	var changeResults []string
 	var warnings []string
-	var currentModuleBuff []string
+	var errorLines []string
+	hasError := false
 
-	// Track current module context
+	var totalImport, totalAdd, totalChange, totalDestroy int
+	planSummaryCount := 0
+	applySummaryCount := 0
+	noChangesCount := 0
+	hasOutputsChanges := false
+
+	// Per-module captured content, in order of first appearance
+	var sections []*moduleSection
+	sectionIndex := map[string]int{}
+	getSection := func(name string) *moduleSection {
+		if idx, ok := sectionIndex[name]; ok {
+			return sections[idx]
+		}
+		sec := &moduleSection{name: name}
+		sectionIndex[name] = len(sections)
+		sections = append(sections, sec)
+		return sec
+	}
+
 	currentModule := ""
-	moduleResults := make(map[string]*ParseResult)
 
 	for i, line := range lines {
-		// Detect module boundaries
-		if match := p.ModuleHeader.FindStringSubmatch(line); len(match) > 1 {
-			// Flush previous module if it had changes
-			if len(currentModuleBuff) > 0 {
-				changeResults = append(changeResults, strings.Join(currentModuleBuff, "\n"))
-				currentModuleBuff = []string{}
-			}
+		stripped := stripTerragruntPrefix(line)
 
-			currentModule = match[1]
-			if consolidated {
-				// Skip the root module "." to avoid empty sections
-				if currentModule == "." {
-					continue
-				}
-				currentModuleBuff = append(currentModuleBuff, currentModule)
-				currentModuleBuff = append(currentModuleBuff, "")
+		// Determine module context. Prefer the [module/path] tag embedded in the
+		// log prefix (terragrunt run-all interleaves output of modules, and the
+		// "Group N / - Module <path>" queue listing is printed before execution
+		// starts, so headers alone cannot attribute output lines correctly).
+		if m := p.LogModule.FindStringSubmatch(line); len(m) == 2 { //nolint:mnd
+			currentModule = m[1]
+		} else if m := p.ModuleHeader.FindStringSubmatch(line); len(m) > 1 {
+			name := m[1]
+			if name == "." {
+				name = ""
 			}
-			if _, exists := moduleResults[currentModule]; !exists {
-				moduleResults[currentModule] = &ParseResult{
-					CreatedResources:  []string{},
-					UpdatedResources:  []string{},
-					DeletedResources:  []string{},
-					ReplacedResources: []string{},
-					MovedResources:    []*MovedResource{},
-					ImportedResources: []string{},
-				}
-			}
+			currentModule = name
 			continue
 		}
 
-		// Parse plan results
-		if p.Pass.MatchString(line) || p.OutputsChanges.MatchString(line) {
-			if result == "" {
-				result = line
-			}
-			if p.HasDestroy.MatchString(line) {
-				hasDestroy = true
-			}
-			if p.HasNoChanges.MatchString(line) {
-				hasNoChanges = true
-			}
-		}
-
-		if p.Fail.MatchString(line) {
+		// Collect error output from the first error line to the end
+		if hasError {
+			errorLines = append(errorLines, stripped)
+		} else if p.Fail.MatchString(line) {
 			hasError = true
-			if result == "" {
-				result = line
-			}
+			errorLines = append(errorLines, stripped)
 		}
-		// Capture content for consolidation
-		if consolidated && currentModule != "" && currentModule != "." {
-			stripped := stripTerragruntPrefix(line)
 
-			// Skip if already captured to avoid duplicates
-			isDuplicate := len(currentModuleBuff) > 0 && currentModuleBuff[len(currentModuleBuff)-1] == stripped
+		// Aggregate plan/apply summaries across all modules
+		summaryLine := false
+		if m := p.PlanSummary.FindStringSubmatch(stripped); len(m) == 5 { //nolint:mnd
+			imported, _ := strconv.Atoi(m[1]) // empty when the plan has no imports
+			add, _ := strconv.Atoi(m[2])
+			change, _ := strconv.Atoi(m[3])
+			destroy, _ := strconv.Atoi(m[4])
+			totalImport += imported
+			totalAdd += add
+			totalChange += change
+			totalDestroy += destroy
+			planSummaryCount++
+			summaryLine = true
+		} else if m := p.ApplySummary.FindStringSubmatch(stripped); len(m) == 4 { //nolint:mnd
+			add, _ := strconv.Atoi(m[1])
+			change, _ := strconv.Atoi(m[2])
+			destroy, _ := strconv.Atoi(m[3])
+			totalAdd += add
+			totalChange += change
+			totalDestroy += destroy
+			applySummaryCount++
+			summaryLine = true
+		} else if p.HasNoChanges.MatchString(line) {
+			noChangesCount++
+			summaryLine = true
+		}
+		if p.OutputsChanges.MatchString(line) {
+			hasOutputsChanges = true
+		}
 
-			if !isDuplicate {
-				if p.Pass.MatchString(line) || p.HasNoChanges.MatchString(line) {
-					// Capture plan summaries and no-changes messages
-					currentModuleBuff = append(currentModuleBuff, stripped)
-				} else if p.Create.MatchString(line) || p.Update.MatchString(line) || p.Delete.MatchString(line) ||
-					p.Replace.MatchString(line) || p.ReplaceOption.MatchString(line) || p.Import.MatchString(line) ||
-					p.ImportedFrom.MatchString(line) || p.Move.MatchString(line) || p.MovedFrom.MatchString(line) {
-					currentModuleBuff = append(currentModuleBuff, stripped)
-				} else if strings.HasPrefix(stripped, "  #") || strings.HasPrefix(stripped, "  +") ||
-					strings.HasPrefix(stripped, "  -") || strings.HasPrefix(stripped, "  ~") ||
-					strings.HasPrefix(stripped, " +/-") || strings.HasPrefix(stripped, "-/+") {
-					// Capture resource diff details
-					currentModuleBuff = append(currentModuleBuff, stripped)
-				} else if strings.HasPrefix(stripped, "Terraform will perform") ||
-					strings.Contains(stripped, "infrastructure matches") ||
-					strings.HasPrefix(stripped, "Changes to Outputs:") {
-					// Capture terraform action headers
-					currentModuleBuff = append(currentModuleBuff, stripped)
+		// Capture per-module plan/apply content (everything between the action
+		// header or first resource action line and the summary line, inclusive)
+		if !hasError {
+			sec := getSection(currentModule)
+			if sec.capturing { //nolint:gocritic
+				sec.lines = append(sec.lines, stripped)
+				if summaryLine {
+					sec.capturing = false
 				}
+			} else if p.ActionHeader.MatchString(stripped) ||
+				strings.HasPrefix(stripped, "Changes to Outputs:") ||
+				p.Create.MatchString(line) || p.Update.MatchString(line) ||
+				p.Delete.MatchString(line) || p.Replace.MatchString(line) ||
+				p.ReplaceOption.MatchString(line) || p.Import.MatchString(line) ||
+				p.Move.MatchString(line) {
+				sec.capturing = true
+				sec.lines = append(sec.lines, stripped)
+			} else if summaryLine {
+				sec.lines = append(sec.lines, stripped)
 			}
 		}
 
 		// Extract resources
 		if rsc := extractResource(p.Create, line); rsc != "" {
 			allCreatedResources = append(allCreatedResources, rsc)
-			if currentModule != "" && moduleResults[currentModule] != nil {
-				moduleResults[currentModule].CreatedResources = append(moduleResults[currentModule].CreatedResources, rsc)
-			}
 		} else if rsc := extractResource(p.Update, line); rsc != "" {
 			allUpdatedResources = append(allUpdatedResources, rsc)
-			if currentModule != "" && moduleResults[currentModule] != nil {
-				moduleResults[currentModule].UpdatedResources = append(moduleResults[currentModule].UpdatedResources, rsc)
-			}
 		} else if rsc := extractResource(p.Delete, line); rsc != "" {
 			allDeletedResources = append(allDeletedResources, rsc)
-			if currentModule != "" && moduleResults[currentModule] != nil {
-				moduleResults[currentModule].DeletedResources = append(moduleResults[currentModule].DeletedResources, rsc)
-			}
 		} else if rsc := extractResource(p.Replace, line); rsc != "" {
 			allReplacedResources = append(allReplacedResources, rsc)
-			if currentModule != "" && moduleResults[currentModule] != nil {
-				moduleResults[currentModule].ReplacedResources = append(moduleResults[currentModule].ReplacedResources, rsc)
-			}
 		} else if rsc := extractResource(p.ReplaceOption, line); rsc != "" {
 			allReplacedResources = append(allReplacedResources, rsc)
-			if currentModule != "" && moduleResults[currentModule] != nil {
-				moduleResults[currentModule].ReplacedResources = append(moduleResults[currentModule].ReplacedResources, rsc)
-			}
 		} else if rsc := extractResource(p.Import, line); rsc != "" {
 			allImportedResources = append(allImportedResources, rsc)
-			if currentModule != "" && moduleResults[currentModule] != nil {
-				moduleResults[currentModule].ImportedResources = append(moduleResults[currentModule].ImportedResources, rsc)
-			}
 		} else if rsc := extractResource(p.ImportedFrom, line); rsc != "" {
 			if i > 0 {
 				if toRsc := p.changedResources(lines[i-1]); toRsc != "" {
 					allImportedResources = append(allImportedResources, toRsc)
-					if currentModule != "" && moduleResults[currentModule] != nil {
-						moduleResults[currentModule].ImportedResources = append(moduleResults[currentModule].ImportedResources, toRsc)
-					}
 				}
 			}
 		} else if rsc := extractMovedResource(p.Move, line); rsc != nil {
 			allMovedResources = append(allMovedResources, rsc)
-			if currentModule != "" && moduleResults[currentModule] != nil {
-				moduleResults[currentModule].MovedResources = append(moduleResults[currentModule].MovedResources, rsc)
-			}
 		} else if fromRsc := extractResource(p.MovedFrom, line); fromRsc != "" {
 			if i > 0 {
 				if toRsc := p.changedResources(lines[i-1]); toRsc != "" {
-					moved := &MovedResource{Before: fromRsc, After: toRsc}
-					allMovedResources = append(allMovedResources, moved)
-					if currentModule != "" && moduleResults[currentModule] != nil {
-						moduleResults[currentModule].MovedResources = append(moduleResults[currentModule].MovedResources, moved)
-					}
+					allMovedResources = append(allMovedResources, &MovedResource{Before: fromRsc, After: toRsc})
 				}
 			}
 		}
 
 		// Collect warnings
 		if p.Warning.MatchString(line) {
-			warnings = append(warnings, line)
+			warnings = append(warnings, stripped)
 		}
 	}
 
-	// Flush final module
-	if len(currentModuleBuff) > 0 {
-		changeResults = append(changeResults, strings.Join(currentModuleBuff, "\n"))
+	// A run has no changes only when no module reported any change at all
+	hasDestroy := totalDestroy > 0
+	hasNoChanges := !hasError && applySummaryCount == 0 &&
+		totalImport == 0 && totalAdd == 0 && totalChange == 0 && totalDestroy == 0 &&
+		(noChangesCount > 0 || planSummaryCount > 0)
+
+	var result string
+	switch {
+	case hasError:
+		result = strings.Join(trimBars(trimLastNewline(errorLines)), "\n")
+	case applySummaryCount > 0:
+		result = fmt.Sprintf("Apply complete! Resources: %d added, %d changed, %d destroyed.", totalAdd, totalChange, totalDestroy)
+	case hasNoChanges:
+		result = "No changes. Your infrastructure matches the configuration."
+	case planSummaryCount > 0:
+		if totalImport > 0 {
+			result = fmt.Sprintf("Plan: %d to import, %d to add, %d to change, %d to destroy.", totalImport, totalAdd, totalChange, totalDestroy)
+		} else {
+			result = fmt.Sprintf("Plan: %d to add, %d to change, %d to destroy.", totalAdd, totalChange, totalDestroy)
+		}
+	case hasOutputsChanges:
+		result = "Only Outputs will be changed."
 	}
 
-	// Build consolidated result
+	// Build the changed result, one section per module
+	var changeResults []string
+	for _, sec := range sections {
+		if len(sec.lines) == 0 {
+			continue
+		}
+		content := strings.TrimRight(strings.Join(sec.lines, "\n"), "\n ")
+		if content == "" {
+			continue
+		}
+		if consolidated && sec.name != "" {
+			content = "Module: " + sec.name + "\n\n" + content
+		}
+		changeResults = append(changeResults, content)
+	}
+
 	hasAddOrUpdateOnly := !hasNoChanges && !hasDestroy && !hasError
 
 	return ParseResult{
 		Result:             strings.TrimSpace(result),
-		ChangedResult:      strings.Join(changeResults, "\n"),
-		Warning:            strings.Join(warnings, "\n"),
+		ChangedResult:      strings.Join(changeResults, "\n\n"),
+		Warning:            strings.TrimSpace(strings.Join(warnings, "\n")),
 		HasAddOrUpdateOnly: hasAddOrUpdateOnly,
 		HasDestroy:         hasDestroy,
 		HasNoChanges:       hasNoChanges,
@@ -589,8 +627,10 @@ func trimBars(list []string) []string {
 	return ret
 }
 
+// terragruntPrefixRe matches Terragrunt timestamp prefixes
+var terragruntPrefixRe = regexp.MustCompile(`^\d{2}:\d{2}:\d{2}\.\d{3} (?:STDOUT|STDERR|INFO|ERROR)\s+(?:\[.*?\]\s+)?(?:tfwrapper\.sh|terraform|tf):\s*`)
+
 // stripTerragruntPrefix removes Terragrunt timestamp prefixes
 func stripTerragruntPrefix(line string) string {
-	re := regexp.MustCompile(`^\d{2}:\d{2}:\d{2}\.\d{3} (?:STDOUT|STDERR|INFO|ERROR)\s+(?:\[.*?\]\s+)?(?:tfwrapper\.sh|terraform|tf):\s*`)
-	return re.ReplaceAllString(line, "")
+	return terragruntPrefixRe.ReplaceAllString(line, "")
 }

--- a/pkg/terraform/parser_terragrunt_test.go
+++ b/pkg/terraform/parser_terragrunt_test.go
@@ -243,6 +243,144 @@ Module /path/to/app2
 	})
 }
 
+func TestTerragruntParser_ConsolidationMixedNoChanges(t *testing.T) {
+	// A module reporting "No changes." before a module with changes must not
+	// mark the whole run as no-changes (regression test)
+	parser := NewTerragruntParser(true)
+
+	input := `18:13:47.247 STDOUT [cluster/shared-vpc] tfwrapper.sh: No changes. Your infrastructure matches the configuration.
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh: Terraform will perform the following actions:
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh:
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh:   # null_resource.test will be created
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh:   + resource "null_resource" "test" {
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh:       + id = (known after apply)
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh:     }
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh:
+18:14:11.466 STDOUT [cluster/cluster] tfwrapper.sh: Plan: 1 to add, 0 to change, 0 to destroy.`
+
+	result := parser.Parse(input)
+
+	if result.HasParseError {
+		t.Fatalf("unexpected parse error: %v", result.Error)
+	}
+	if result.HasNoChanges {
+		t.Error("HasNoChanges = true, want false (one module has changes)")
+	}
+	if result.Result != "Plan: 1 to add, 0 to change, 0 to destroy." {
+		t.Errorf("Result = %q, want aggregated plan summary", result.Result)
+	}
+	if len(result.CreatedResources) != 1 {
+		t.Errorf("CreatedResources count = %d, want 1", len(result.CreatedResources))
+	}
+	// Module attribution must come from the [module/path] log prefix
+	if !strings.Contains(result.ChangedResult, "cluster/cluster") {
+		t.Errorf("ChangedResult missing module name from log prefix:\n%s", result.ChangedResult)
+	}
+	// Nested diff lines must be preserved
+	if !strings.Contains(result.ChangedResult, "+ id = (known after apply)") {
+		t.Errorf("ChangedResult missing nested diff line:\n%s", result.ChangedResult)
+	}
+	if !strings.Contains(result.ChangedResult, "Plan: 1 to add, 0 to change, 0 to destroy.") {
+		t.Errorf("ChangedResult missing plan summary:\n%s", result.ChangedResult)
+	}
+}
+
+func TestTerragruntParser_ConsolidationAggregatesTotals(t *testing.T) {
+	parser := NewTerragruntParser(true)
+
+	input := `Group 1
+Module /path/to/app1
+
+09:32:46.963 STDOUT terraform:   # null_resource.app1 will be created
+09:32:46.963 STDOUT terraform: Plan: 2 to add, 1 to change, 0 to destroy.
+
+Group 2
+Module /path/to/app2
+
+09:33:12.145 STDOUT terraform:   # null_resource.app2 will be destroyed
+09:33:12.145 STDOUT terraform: Plan: 1 to add, 0 to change, 3 to destroy.`
+
+	result := parser.Parse(input)
+
+	if result.Result != "Plan: 3 to add, 1 to change, 3 to destroy." {
+		t.Errorf("Result = %q, want aggregated totals", result.Result)
+	}
+	if !result.HasDestroy {
+		t.Error("HasDestroy = false, want true")
+	}
+	if result.HasNoChanges {
+		t.Error("HasNoChanges = true, want false")
+	}
+}
+
+func TestTerragruntParser_ErrorKeepsDetails(t *testing.T) {
+	parser := NewTerragruntParser(true)
+
+	input := `09:32:46.963 STDOUT terraform: Initializing...
+09:32:46.963 STDERR terraform: Error: Invalid configuration
+09:32:46.963 STDERR terraform:
+09:32:46.963 STDERR terraform: Something went wrong
+09:32:46.963 STDERR terraform: on main.tf line 5`
+
+	result := parser.Parse(input)
+
+	if !result.HasError {
+		t.Fatal("HasError = false, want true")
+	}
+	// The full error details (prefix-stripped) must be preserved, not just the first line
+	if !strings.Contains(result.Result, "Error: Invalid configuration") {
+		t.Errorf("Result missing error headline: %q", result.Result)
+	}
+	if !strings.Contains(result.Result, "Something went wrong") {
+		t.Errorf("Result missing error details: %q", result.Result)
+	}
+	if strings.Contains(result.Result, "STDERR") {
+		t.Errorf("Result should not contain log prefixes: %q", result.Result)
+	}
+}
+
+func TestTerragruntParser_PlanSummaryWithImports(t *testing.T) {
+	// Terraform >= 1.5 prints "Plan: N to import, ..." when import blocks are used
+	parser := NewTerragruntParser(true)
+
+	input := `09:32:46.963 STDOUT terraform:   # null_resource.test will be imported
+09:32:46.963 STDOUT terraform: Plan: 1 to import, 2 to add, 0 to change, 0 to destroy.`
+
+	result := parser.Parse(input)
+
+	if result.HasParseError {
+		t.Fatalf("unexpected parse error: %v", result.Error)
+	}
+	if result.HasNoChanges {
+		t.Error("HasNoChanges = true, want false")
+	}
+	if result.Result != "Plan: 1 to import, 2 to add, 0 to change, 0 to destroy." {
+		t.Errorf("Result = %q, want import-aware plan summary", result.Result)
+	}
+	if len(result.ImportedResources) != 1 {
+		t.Errorf("ImportedResources count = %d, want 1", len(result.ImportedResources))
+	}
+}
+
+func TestTerragruntParser_ApplyConsolidated(t *testing.T) {
+	parser := NewTerragruntParser(true)
+
+	input := `18:13:47.247 STDOUT [app1] tfwrapper.sh: Apply complete! Resources: 2 added, 1 changed, 0 destroyed.
+18:14:11.466 STDOUT [app2] tfwrapper.sh: Apply complete! Resources: 1 added, 0 changed, 1 destroyed.`
+
+	result := parser.Parse(input)
+
+	if result.HasParseError {
+		t.Fatalf("unexpected parse error: %v", result.Error)
+	}
+	if result.HasError {
+		t.Error("HasError = true, want false")
+	}
+	if result.Result != "Apply complete! Resources: 3 added, 1 changed, 1 destroyed." {
+		t.Errorf("Result = %q, want aggregated apply summary", result.Result)
+	}
+}
+
 func TestStripTerragruntPrefix(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/terraform/parser_terragrunt_test.go
+++ b/pkg/terraform/parser_terragrunt_test.go
@@ -313,6 +313,83 @@ Module /path/to/app2
 	}
 }
 
+func TestTerragruntParser_ConsolidatedModuleResults(t *testing.T) {
+	parser := NewTerragruntParser(true)
+
+	// Two named modules with mixed Create/Update changes, mirroring the
+	// shape mstf-ci produces via `terragrunt run-all plan` with no tfwrapper.
+	// The [module/path] log prefix is what LogModule keys on for attribution.
+	input := `Group 1
+- Module /repo/cluster-citadel-2g/regions/tokyo/shared-vpc
+
+10:23:45.001 STDOUT [cluster-citadel-2g/regions/tokyo/shared-vpc] tf:   # terraform_data.tfnotify_consolidation_canary will be created
+10:23:45.001 STDOUT [cluster-citadel-2g/regions/tokyo/shared-vpc] tf:   # google_project_iam_member.tushar_is_owner will be created
+10:23:45.001 STDOUT [cluster-citadel-2g/regions/tokyo/shared-vpc] tf: Plan: 2 to add, 0 to change, 0 to destroy.
+
+Group 2
+- Module /repo/cluster-spinnaker/regions/tokyo/cluster
+
+10:24:05.222 STDOUT [cluster-spinnaker/regions/tokyo/cluster] tf:   # google_container_node_pool.nodepool["spinnaker-general-t2d-standard-8-preemptible-003"] will be updated in-place
+10:24:05.222 STDOUT [cluster-spinnaker/regions/tokyo/cluster] tf:   # terraform_data.tfnotify_consolidation_canary will be created
+10:24:05.222 STDOUT [cluster-spinnaker/regions/tokyo/cluster] tf: Plan: 1 to add, 1 to change, 0 to destroy.`
+
+	result := parser.Parse(input)
+
+	if len(result.ModuleResults) != 2 {
+		t.Fatalf("ModuleResults length = %d, want 2:\n%+v", len(result.ModuleResults), result.ModuleResults)
+	}
+
+	first := result.ModuleResults[0]
+	if first.Module != "cluster-citadel-2g/regions/tokyo/shared-vpc" {
+		t.Errorf("ModuleResults[0].Module = %q, want shared-vpc path", first.Module)
+	}
+	if len(first.CreatedResources) != 2 {
+		t.Errorf("ModuleResults[0].CreatedResources = %v, want 2 entries", first.CreatedResources)
+	}
+	if len(first.UpdatedResources) != 0 {
+		t.Errorf("ModuleResults[0].UpdatedResources = %v, want 0 entries", first.UpdatedResources)
+	}
+
+	second := result.ModuleResults[1]
+	if second.Module != "cluster-spinnaker/regions/tokyo/cluster" {
+		t.Errorf("ModuleResults[1].Module = %q, want spinnaker cluster path", second.Module)
+	}
+	if len(second.CreatedResources) != 1 {
+		t.Errorf("ModuleResults[1].CreatedResources = %v, want 1 entry", second.CreatedResources)
+	}
+	if len(second.UpdatedResources) != 1 {
+		t.Errorf("ModuleResults[1].UpdatedResources = %v, want 1 entry", second.UpdatedResources)
+	}
+
+	// Flat lists must still total the union (back-compat for older templates).
+	if len(result.CreatedResources) != 3 {
+		t.Errorf("CreatedResources (flat) = %v, want 3 entries", result.CreatedResources)
+	}
+	if len(result.UpdatedResources) != 1 {
+		t.Errorf("UpdatedResources (flat) = %v, want 1 entry", result.UpdatedResources)
+	}
+}
+
+func TestTerragruntParser_ConsolidatedNotEmittedForSingleUnnamed(t *testing.T) {
+	parser := NewTerragruntParser(true)
+
+	// Single-module input with no [module/path] log prefix and no run-all
+	// queue header. Consolidated mode should NOT emit ModuleResults — older
+	// templates would otherwise see a single "Root module" heading for no
+	// observable benefit. They fall back to the flat lists.
+	input := `09:32:46.963 STDOUT terraform:   # null_resource.test will be created
+09:32:46.963 STDOUT terraform: Plan: 1 to add, 0 to change, 0 to destroy.`
+
+	result := parser.Parse(input)
+
+	if result.ModuleResults != nil {
+		t.Errorf("ModuleResults = %+v, want nil for single-unnamed-module input", result.ModuleResults)
+	}
+	if len(result.CreatedResources) != 1 {
+		t.Errorf("CreatedResources (flat) = %v, want 1 entry", result.CreatedResources)
+	}
+}
+
 func TestTerragruntParser_ErrorKeepsDetails(t *testing.T) {
 	parser := NewTerragruntParser(true)
 

--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -97,8 +97,13 @@ type CommonTemplate struct {
 	ReplacedResources      []string
 	MovedResources         []*MovedResource
 	ImportedResources      []string
-	AISummary              string
-	SummaryEnabled         bool
+	// ModuleResults is populated by TerragruntParser in consolidated mode when
+	// the parsed body contains multiple Terragrunt modules. The default
+	// `updated_resources` template renders a per-module Create/Update/Delete
+	// summary when this is non-empty, falling back to the flat lists otherwise.
+	ModuleResults []*ModuleResult
+	AISummary      string
+	SummaryEnabled bool
 }
 
 // Template is a default template for terraform commands
@@ -229,6 +234,7 @@ func (t *Template) Execute() (string, error) {
 		"ReplacedResources":      t.ReplacedResources,
 		"MovedResources":         t.MovedResources,
 		"ImportedResources":      t.ImportedResources,
+		"ModuleResults":          t.ModuleResults,
 		"HasDestroy":             t.HasDestroy,
 		"AISummary":              t.AISummary,
 		"SummaryEnabled":         t.SummaryEnabled,
@@ -239,7 +245,9 @@ func (t *Template) Execute() (string, error) {
 		"apply_title": "## {{if and (eq .ExitCode 0) (not .HasError)}}:white_check_mark: Apply Succeeded{{else}}:x: Apply Failed{{end}}{{if .Vars.target}} ({{.Vars.target}}){{end}}",
 		"result":      "{{if .Result}}<pre><code>{{ .Result }}</code></pre>{{end}}",
 		"ai_summary":  "{{if .SummaryEnabled}}{{if .AISummary}}<details><summary>AI Summary (Click me)</summary>\n\n{{avoidHTMLEscape .AISummary}}\n\n</details>{{end}}{{end}}",
-		"updated_resources": `{{if .CreatedResources}}
+		"updated_resources": `{{if .ModuleResults}}{{range .ModuleResults}}
+### {{.Module}}
+{{if .CreatedResources}}
 * Create
 {{- range .CreatedResources}}
   * {{.}}
@@ -263,7 +271,32 @@ func (t *Template) Execute() (string, error) {
 * Move
 {{- range .MovedResources}}
   * {{.Before}} => {{.After}}
-{{- end}}{{end}}`,
+{{- end}}{{end}}
+{{end}}{{else}}{{if .CreatedResources}}
+* Create
+{{- range .CreatedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .UpdatedResources}}
+* Update
+{{- range .UpdatedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .DeletedResources}}
+* Delete
+{{- range .DeletedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .ReplacedResources}}
+* Replace
+{{- range .ReplacedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .ImportedResources}}
+* Import
+{{- range .ImportedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .MovedResources}}
+* Move
+{{- range .MovedResources}}
+  * {{.Before}} => {{.After}}
+{{- end}}{{end}}{{end}}`,
 		"deletion_warning": `{{if .HasDestroy}}
 ### :warning: Resource Deletion will happen
 This plan contains resource delete operation. Please check the plan result very carefully!


### PR DESCRIPTION
## WHAT
The patch contains, fixes for consolidation mode for Terragrunt and Slack notification for the same. If consolidation mode is enabled, Terragrunt modules were reporting on the parentTs only, causing noise.
(Write the change being made with this pull request)

## WHY
To ensure stability for this feature.
(Write the motivation why you submit this pull request)
